### PR TITLE
CR 1125208 - Updated init.tcl

### DIFF
--- a/ced/Xilinx/IPI/Versal_ACAP_Processor_Performance/init.tcl
+++ b/ced/Xilinx/IPI/Versal_ACAP_Processor_Performance/init.tcl
@@ -26,7 +26,7 @@ proc getSupportedParts {} {
 proc getSupportedBoards {} {
 # return [get_board_parts -filter {(BOARD_NAME =~"*vck190*" && VENDOR_NAME=="xilinx.com") || (BOARD_NAME =~"*vmk180*" && VENDOR_NAME=="xilinx.com")}  -latest_file_version]
  
- return [get_board_parts -filter {(BOARD_NAME =~"*vck190*" && VENDOR_NAME=="xilinx.com" && PART_NAME=~"xcvc1902-vsva2197-2MP-e-S") || (BOARD_NAME =~"*vmk180*" && VENDOR_NAME=="xilinx.com" && PART_NAME=~"xcvm1802-vsva2197-2MP-e-S")}  -latest_file_version]
+ return [get_board_parts -filter {(BOARD_NAME =~"*vck190" && VENDOR_NAME=="xilinx.com" && PART_NAME=~"xcvc1902-vsva2197-2MP-e-S") || (BOARD_NAME =~"*vmk180" && VENDOR_NAME=="xilinx.com" && PART_NAME=~"xcvm1802-vsva2197-2MP-e-S")}  -latest_file_version]
 }
 
 proc addOptions {DESIGNOBJ} {
@@ -51,5 +51,3 @@ proc addGUILayout {DESIGNOBJ} {
 	 set Preset.ENABLEMENT true
   }
 }
-
-


### PR DESCRIPTION
Modified init.tcl to support only Versal ACAP Processor Performance CED is supporting level shifter vck190:part0 board.