### PR TITLE
CR-1144657 - Added Readme.txt and steps for exporting HW Emulation XSA for DFX CED

### DIFF
--- a/ced/Xilinx/IPI/Versal_Extensible_Embedded_Platform/README.md
+++ b/ced/Xilinx/IPI/Versal_Extensible_Embedded_Platform/README.md
@@ -5,8 +5,8 @@ It gives the kernels access to DDR memory, an interrupt controller, and clocking
 
 1. Execute below commands in the terminal before launching vivado
 
-	source Installarea/installs/lin64/Vitis/Installedversion/settings64.csh
-	export JSON_DEVICE_FILE_PATH=Installarea/installs/lin64/Vitis/Installedversion/aietools/data/aie_ml/devices/VC2802.json
+		source Installarea/installs/lin64/Vitis/Installedversion/settings64.csh
+		export JSON_DEVICE_FILE_PATH=Installarea/installs/lin64/Vitis/Installedversion/aietools/data/aie_ml/devices/VC2802.json
 
 
 2. In batch mode follow the below commands if trying to execute Non-AIE simulation flow on AIE platform

--- a/ced/Xilinx/IPI/Versal_Extensible_Embedded_Platform/README.md
+++ b/ced/Xilinx/IPI/Versal_Extensible_Embedded_Platform/README.md
@@ -1,0 +1,27 @@
+An extensible platform is the foundation of the Vitis software acceleration flow. This platform enables Vitis to create AIE kernels and PL kernels. 
+It gives the kernels access to DDR memory, an interrupt controller, and clocking resources. Extensible interfaces are marked with PFM properties and the platform is exported to Vitis using write_hw_platform to create an XSA.
+
+## Instructions for VEK280 board AIE Simulation flow
+
+1. Execute below commands in the terminal before launching vivado
+
+	source Installarea/installs/lin64/Vitis/Installedversion/settings64.csh
+	export JSON_DEVICE_FILE_PATH=Installarea/installs/lin64/Vitis/Installedversion/aietools/data/aie_ml/devices/VC2802.json
+
+
+2. In batch mode follow the below commands if trying to execute Non-AIE simulation flow on AIE platform
+
+		update_compile_order -fileset sim_1
+		set_property top ext_platform_wrapper [current_fileset]
+		launch_simulation -scripts_only
+		update_compile_order -fileset sim_1
+		set_property top ext_platform_wrapper_sim_wrapper [get_filesets sim_1]
+		import_files -fileset sim_1 -norecurse ./project_1/project_1.srcs/sources_1/common/hdl/ext_platform_wrapper_sim_wrapper.v
+		update_compile_order -fileset sim_1
+		set_property target_simulator {Vivado Simulator} [current_project]
+		set_property -name {xsim.simulate.runtime} -value {0ns} -objects [current_fileset -simset]
+		launch_simulation -simset sim_1 -mode behavioral
+		close_sim
+	
+Notes : "Installarea" is the drirectory where the vivado is being installed.
+		"ext_platform_wrapper" is top BD wrapper,based on the block design created in CED flow.

--- a/ced/Xilinx/IPI/versal_dfx/README.md
+++ b/ced/Xilinx/IPI/versal_dfx/README.md
@@ -19,9 +19,10 @@ Versal AI Core Series VCK190 Evaluation Kit is required.
 This Example design contains a top BD (versal_dfx_platform.bd) and a DFX BD(VitisRegion). What ever the Configurations selected in GUI will be added to VitisRegion.bd with Dynamic Function eXchange feature and boundary constraints. 
   
 Note: Block Diagram will vary according to GUI options selected.
-
+      User can skip from step-1 to step-8 as these are covered in default CED flow until unless, wants to modify the design by adding another RP or RM, launching DFX wizard to modify the configuartion runs etc.    
+	  
 Running the DFX Flow
-1. IP output products are not included as part of the example design and need to be generated. Generate output products for the block design. Select global for a quick turnaround.
+1. Generate output products for the block design. Select global for a quick turnaround.
 
 ## Output Products
 
@@ -66,3 +67,11 @@ Click on 'Dynamic Function eXchange Wizard' in the Flow Navigator. Click Next
 		
 		b.file mkdir rp (make directory)
 		  write_hw_platform  -rp versal_dfx_platform_i/VitisRegion rp/rp.xsa
+		
+        Note: User have to execute below commands to export XSA for hardware emulation flow.
+			  set_property platform.name {name} [current_project]
+			  set_property pfm_name {xilinx:vck190:name:0.0} [get_files -all VitisRegion.bd] (example for vck190 board)
+			  set_property platform.platform_state {pre_synth} [current_project]
+			  set_property platform.uses_pr {true} [current_project]
+			  write_hw_platform -hw_emu -force -file ./hw_emu.xsa
+		  


### PR DESCRIPTION
1. Added README file with Instructions for VEK280 board AIE Simulation flow for Versal_Extensible_Embedded_Platform CED.
2. Add steps in README for exporting HW Emulation XSA for versal_dfx CED.