### PR TITLE
CR-1160396 - Versal ACAP CPM QDMA EP Design update wrt CIPS bootmode

### DIFF
--- a/ced/Xilinx/IPI/Versal_ACAP_CPM_QDMA_EP_Design/cpm5_qdma_dual_ctrl/design_1_bd.tcl
+++ b/ced/Xilinx/IPI/Versal_ACAP_CPM_QDMA_EP_Design/cpm5_qdma_dual_ctrl/design_1_bd.tcl
@@ -719,6 +719,7 @@ NONE HBM_PC1_USER_DEFINED_ADDRESS_MAP NONE} \
   # Create instance: versal_cips_1, and set properties
   set versal_cips_1 [ create_bd_cell -type ip -vlnv xilinx.com:ip:versal_cips versal_cips_1 ]
   set_property -dict [list \
+    CONFIG.BOOT_MODE {Custom} \
     CONFIG.CLOCK_MODE {Custom} \
     CONFIG.CPM_CONFIG { \
       CPM_PCIE0_ACS_CAP_ON {1} \
@@ -879,12 +880,16 @@ NONE HBM_PC1_USER_DEFINED_ADDRESS_MAP NONE} \
       CPM_PCIE1_TL_PF_ENABLE_REG {4} \
     } \
     CONFIG.PS_PMC_CONFIG { \
+      BOOT_MODE {Custom} \
       CLOCK_MODE {Custom} \
       DESIGN_MODE {1} \
       PCIE_APERTURES_DUAL_ENABLE {1} \
       PCIE_APERTURES_SINGLE_ENABLE {0} \
       PMC_CRP_PL0_REF_CTRL_FREQMHZ {250} \
       PMC_OT_CHECK {{DELAY 0} {ENABLE 0}} \
+      PMC_QSPI_FBCLK {{ENABLE 0} {IO {PMC_MIO 6}}} \
+      PMC_QSPI_PERIPHERAL_ENABLE {1} \
+      PMC_QSPI_PERIPHERAL_MODE {Dual Parallel} \
       PS_BOARD_INTERFACE {Custom} \
       PS_PCIE1_PERIPHERAL_ENABLE {1} \
       PS_PCIE2_PERIPHERAL_ENABLE {1} \

--- a/ced/Xilinx/IPI/Versal_ACAP_CPM_QDMA_EP_Design/cpm5_qdma_mm_only/design_1_bd.tcl
+++ b/ced/Xilinx/IPI/Versal_ACAP_CPM_QDMA_EP_Design/cpm5_qdma_mm_only/design_1_bd.tcl
@@ -697,6 +697,7 @@ proc create_root_design { parentCell } {
       PCIE_APERTURES_DUAL_ENABLE {0} \
       PCIE_APERTURES_SINGLE_ENABLE {1} \
       PMC_CRP_PL0_REF_CTRL_FREQMHZ {250} \
+      PMC_QSPI_FBCLK {{ENABLE 0} {IO {PMC_MIO 6}}} \
       PMC_QSPI_PERIPHERAL_ENABLE {1} \
       PMC_QSPI_PERIPHERAL_MODE {Dual Parallel} \
       PS_BOARD_INTERFACE {Custom} \

--- a/ced/Xilinx/IPI/Versal_ACAP_CPM_QDMA_EP_Design/cpm5_qdma_st_only/src/design_1_wrapper.sv
+++ b/ced/Xilinx/IPI/Versal_ACAP_CPM_QDMA_EP_Design/cpm5_qdma_st_only/src/design_1_wrapper.sv
@@ -594,6 +594,27 @@ module design_1_wrapper #
       .PCIE1_GT_0_gtx_n(PCIE1_GT_0_gtx_n),
       .PCIE1_GT_0_gtx_p(PCIE1_GT_0_gtx_p),
  
+ //Lite 1      
+      .M_AXIL_araddr  (m_axil_araddr),
+      .M_AXIL_arprot  (m_axil_arprot),
+      .M_AXIL_arready (m_axil_arready),
+      .M_AXIL_arvalid (m_axil_arvalid),
+      .M_AXIL_awaddr  (m_axil_awaddr),
+      .M_AXIL_awprot  (m_axil_awprot),
+      .M_AXIL_awready (m_axil_awready),
+      .M_AXIL_awvalid (m_axil_awvalid),
+      .M_AXIL_bready  (m_axil_bready),
+      .M_AXIL_bresp   (m_axil_bresp),
+      .M_AXIL_bvalid  (m_axil_bvalid),
+      .M_AXIL_rdata   (m_axil_rdata),
+      .M_AXIL_rready  (m_axil_rready),
+      .M_AXIL_rresp   (m_axil_rresp),
+      .M_AXIL_rvalid  (m_axil_rvalid),
+      .M_AXIL_wdata   (m_axil_wdata),
+      .M_AXIL_wready  (m_axil_wready),
+      .M_AXIL_wstrb   (m_axil_wstrb),
+      .M_AXIL_wvalid  (m_axil_wvalid),
+      
       // To AXIL BRAM
       .S_AXIL_araddr  (m_axil_araddr[11:0]),
       .S_AXIL_arprot  (m_axil_arprot),

--- a/ced/Xilinx/IPI/Versal_ACAP_CPM_QDMA_EP_Design/create_cpm5.tcl
+++ b/ced/Xilinx/IPI/Versal_ACAP_CPM_QDMA_EP_Design/create_cpm5.tcl
@@ -420,6 +420,7 @@ NONE HBM_PC1_USER_DEFINED_ADDRESS_MAP NONE} \
   # Create instance: versal_cips_1, and set properties
   set versal_cips_1 [ create_bd_cell -type ip -vlnv xilinx.com:ip:versal_cips versal_cips_1 ]
   set_property -dict [list \
+    CONFIG.BOOT_MODE {Custom} \
     CONFIG.CLOCK_MODE {Custom} \
     CONFIG.CPM_CONFIG { \
       CPM_PCIE0_ACS_CAP_ON {1} \
@@ -580,12 +581,16 @@ NONE HBM_PC1_USER_DEFINED_ADDRESS_MAP NONE} \
       CPM_PCIE1_TL_PF_ENABLE_REG {4} \
     } \
     CONFIG.PS_PMC_CONFIG { \
+      BOOT_MODE {Custom} \
       CLOCK_MODE {Custom} \
       DESIGN_MODE {1} \
       PCIE_APERTURES_DUAL_ENABLE {0} \
       PCIE_APERTURES_SINGLE_ENABLE {1} \
       PMC_CRP_PL0_REF_CTRL_FREQMHZ {250} \
       PMC_OT_CHECK {{DELAY 0} {ENABLE 0}} \
+      PMC_QSPI_FBCLK {{ENABLE 0} {IO {PMC_MIO 6}}} \
+      PMC_QSPI_PERIPHERAL_ENABLE {1} \
+      PMC_QSPI_PERIPHERAL_MODE {Dual Parallel} \
       PS_BOARD_INTERFACE {Custom} \
       PS_PCIE1_PERIPHERAL_ENABLE {0} \
       PS_PCIE2_PERIPHERAL_ENABLE {1} \
@@ -662,7 +667,7 @@ set_property CONFIG.PS_PMC_CONFIG { PS_PCIE_EP_RESET2_IO {PS_MIO 19} PS_PCIE_RES
   assign_bd_address -offset 0x020100000000 -range 0x00100000 -target_address_space [get_bd_addr_spaces versal_cips_1/CPM_PCIE_NOC_0] [get_bd_addr_segs axi_bram_ctrl_0/S_AXI/Mem0] -force
   assign_bd_address -offset 0x00000000 -range 0x80000000 -target_address_space [get_bd_addr_spaces versal_cips_1/CPM_PCIE_NOC_0] [get_bd_addr_segs axi_noc_0/S00_AXI/C0_DDR_LOW0] -force
   assign_bd_address -offset 0x000800000000 -range 0x80000000 -target_address_space [get_bd_addr_spaces versal_cips_1/CPM_PCIE_NOC_0] [get_bd_addr_segs axi_noc_0/S00_AXI/C0_DDR_LOW1] -force
-  assign_bd_address -offset 0x020200000000 -range 0x00100000 -target_address_space [get_bd_addr_spaces versal_cips_1/CPM_PCIE_NOC_0] [get_bd_addr_segs pcie_qdma_mailbox_1/S_AXI_LITE/Reg] -force
+  assign_bd_address -offset 0x020200000000 -range 0x80000000 -target_address_space [get_bd_addr_spaces versal_cips_1/CPM_PCIE_NOC_0] [get_bd_addr_segs pcie_qdma_mailbox_1/S_AXI_LITE/Reg] -force
   assign_bd_address -offset 0x020180000000 -range 0x00100000 -target_address_space [get_bd_addr_spaces versal_cips_1/CPM_PCIE_NOC_1] [get_bd_addr_segs M_AXIL/Reg] -force
   assign_bd_address -offset 0x020100000000 -range 0x00100000 -target_address_space [get_bd_addr_spaces versal_cips_1/CPM_PCIE_NOC_1] [get_bd_addr_segs axi_bram_ctrl_0/S_AXI/Mem0] -force
   assign_bd_address -offset 0x00000000 -range 0x80000000 -target_address_space [get_bd_addr_spaces versal_cips_1/CPM_PCIE_NOC_1] [get_bd_addr_segs axi_noc_0/S01_AXI/C0_DDR_LOW0] -force


### PR DESCRIPTION
Updated the design with CIPS bootmode and address map for CPM5 CPM5_QDMA_Gen4x8_MM_ST