### PR TITLE
CR-1223286 - Adding support for MP device with VPK120 board

### DIFF
--- a/ced/Xilinx/IPI/Versal_CPM_QDMA_Accel_Sys_Design/README.txt
+++ b/ced/Xilinx/IPI/Versal_CPM_QDMA_Accel_Sys_Design/README.txt
@@ -4,42 +4,108 @@ This example design will show-case end user application features to demonstrate 
 
 This design will cover the following functionalities:
 
-  Segmented Configuration
-  Load PLD image over PCIe to SBI – use QDMA driver.
-  For the QDMA-MM data path - H2C/C2H:
-    - Execution of H2C transfer
-    - Generation of IPI Interrupt
-    - Processing of H2C data
-    - Triggering of an interrupt to the host via the usr_irq interface of CPM5-QDMA from the APU
-    - Completion of C2H transfer
-  The H2C data processing is initiated by an application on the APU (A72).
-  Regarding the QDMA-ST data path - H2C/C2H:
-    - Implementation of H2C transfer
-    - Processing of H2C data
-    - Retrieval of descriptors through the dsc_crdt/dsc_byp interfaces of CPM5-QDMA
-    - Execution of C2H transfer
-  The C2H-ST transfer is supported using:
+  * Segmented Configuration
+    - Load PLD image over PCIe to SBI – use QDMA driver.
+  * QDMA-MM data path - H2C/C2H: Following steps show a process of transferring data from Host machine to Accelerator logic inside PL, processing 
+    the data and fetching the processed data back to host memory. 
+    - Transfer the data in host memory to a DDR attached to the Versal Premium device. Use QDMA Driver running on PCIe host to perform the H2C DMA transfer.
+    - Generate IPI Interrupt on completion of H2C DMA transfer. This IPI interrupt is targeted to PS APU in Versal Premium Device. 
+    - A Baremetal Application running on the APU responds to IPI interrupt and programs AXI-DMA IP in the PL.
+    - AXI-DMA IP transfers the data from DDR to the Accelerator logic in the PL. 
+    - Accelerator logic performs the processing of H2C data and writes the output data back to DDR memory. 
+    - PL will generate an interrupt to the host via the usr_irq interface of CPM5-QDMA. 
+    - Use QDMA driver to perform C2H DMA transfer from DDR memory to Host memory.   
+  * QDMA-ST data path - H2C/C2H:
+    - Using QDMA driver, transfer the data in host memory to Accelerator logic to PL using H2C-ST DMA transfer
+    - Process the H2C-ST data and store it in Stream FIFO
+    - Perform C2H-ST data transfer
+  * The C2H-ST transfer is supported using:
     - Internal method
     - Simple bypass method
     - Csh bypass method
-  Access to the following memory regions via the PCIe link will be demonstrated
+  * Access to the following memory regions via the PCIe link will be demonstrated
     - OCM
     - RTCA
     - SBI
     - QSPI
     - CPM
     - Inter Processer Interrupt registers
+    
+For additional details of the CED, please refer to the readme.md file available in the git repository of this CED. 
+    
+VPK120 board has two device variants with MP and MHP parts.
 
-NOTE: This design requires a baremetal application to be executing while performing MM transfers. Following
+The VPK120 evaluation kit has a physical x16 edge connector and enables protocol support in two flavors depending on whether overdrive is used or not.
+With overdrive, the VPK120 supports: Gen1/2/3/4x16 or Gen5x8.
+
+Without overdrive, the VPK120 supports: Gen1/2/3x16 or Gen4x8.
+
+Gen5 is not supported without overdrive.
+
+Depending on the device selected during the CED creation, the target data rate is selected.
+
+For MP part, design is generated with Gen4 x8 configuration.
+For MHP part, design is generated with Gen5 x8 configuration.
+
+NOTE: 
+1. This design requires a baremetal application to be executing while performing MM transfers. Following
 command needs to be executed after generating the PDI from Vivado. 
 
-qdma_accel_sys.bif assumes that ipi_cdma_intr.elf and design_1_wrapper_pld.pdi are in the same directory as the bif file.  
-bootgen -arch versal -image ./qdma_accel_sys.bif -o ./pld_with_elf.pdi -w
+qdma_accel_sys.bif assumes that ipi_cdma_intr.elf and design_1_wrapper_boot.pdi are in the same directory as the bif file.  
+bootgen -arch versal -image ./qdma_accel_sys.bif -o ./boot_with_elf.pdi -w
 
-Following scripts are provided with the CED for reference. 
-1. qdma_test_h2c_mm.sh -- Tests the MM data path of the design. 
-2. qdma_test_h2c_st.sh -- Tests the ST data path of the design. This script requires h2c_data.txt file. 
+2. This CED is only provided for hardware test flow. Simulation is not supported. 
+
+Required Hardware and Tools:
+
+Vivado 2025.1
+Vitis 2025.1
+
+Design Steps:
+
+1. Open Vivado and select XHub Stores in Tools tab
+2. Install Versal_CPM_QDMA_Accel_Sys_Design
+3. Close that window and select Open Example Project
+4. Create Versal_CPM_QDMA_Accel_Sys_Design vivado project and generate .pdi by selecting Generate Device Image
+This design requires a baremetal application to be executing while performing MM transfers. Following command needs to be executed after generating the PDI from Vivado. ipi_cdma_intr.elf and qdma_accel_sys.bif are provided in src directory of this CED.
+
+qdma_accel_sys.bif assumes that ipi_cdma_intr.elf and design_1_wrapper_boot.pdi are in the same directory as the bif file.
+bootgen -arch versal -image ./qdma_accel_sys.bif -o ./boot_with_elf.pdi -w
+
+Test Scripts:
+
+Pre-requisite to source this script: QDMA driver must be installed in the host and it is linked to the QDMA End point running on the VPK120 board.
+
+Following scripts are provided with the CED for reference. They are available in scripts folder of this CED.
+
+1. qdma_test_h2c_mm.sh -- Tests the MM data path of the design. This script performs the following steps.
+
+   - Identify bus, device, function (BDF) numbers of the PCIe slot to which VPK120 board is connected to. This design is set with DEVICE_ID of "10EE". This value is used for the BDF identification process.
+   - Create MM QID for H2C/C2H directions
+   - Start the QID
+   - Perform H2C-MM DMA transfer to 0x72000000000 DDR address.
+   - Initiate IPI interrupt to A72 processor in Versal Premium device. IPI message sent through IPI interrupt consists of the following details.
+     - DDR address used in H2C-MM DMA transfer
+     - QID used in H2C-MM DMA transfer
+     - Size of the H2C-MM DMA transfer
+2. qdma_test_h2c_st.sh -- Tests the ST data path of the design. This script requires h2c_data.txt file. This script performs the following steps.
+
+   - Identify bus, device, function (BDF) numbers of the PCIe slot to which VPK120 board is connected to. This design is set with DEVICE_ID of "10EE". This value is used for the BDF identification process.
+   - This script has desc_bypass_en, pfetch_bypass_en, trfr_size0, trfr_size1, trfr_size2 variables.
+   - desc_bypass_en, pfetch_bypass_en are used to set different C2H-ST use modes (Simple bypass, Csh bypass, Csh Internal) for C2H-ST QID.
+      - Simple bypass mode --> desc_bypass_en = 1, pfetch_bypass_en = 1
+      - Csh bypass mode --> desc_bypass_en = 1, pfetch_bypass_en = 0
+      - Csh Internal mode --> desc_bypass_en = 0, pfetch_bypass_en = 0
+      - trfr_size0 - size of DMA transfer with Csh Internal mode
+      - trfr_size1 - size of DMA transfer with Csh bypass mode
+      - trfr_size2 - size of DMA transfer with simple bypass mode
+   - Create ST QID for H2C-ST direction
+   - Create ST QID for C2H-ST direction based on desc_bypass_en, pfetch_bypass_en
+   - Start the QID H2C-ST and C2H-ST directions.
+   - Perform H2C-ST DMA transfer to PL
 3. access_PS_peripherals.sh -- Tests the access to the memory regions such as OCM, RTCA, SBI, QSPI, CPM.
+   - This script assumes BDF value of 01000 to access the PMC peripherals.
+4. host_profile_noc0_1.sh -- Programs host profile registers of QDMA to perform MM transfers to NoC Ch#0 and Ch#
 
 The QDMA driver that should be used with this design can be found on GitHub
 at the below link and there is a set of example Linux shell scripts that can 
@@ -49,11 +115,22 @@ compile and install the driver on your host system.
 
   https://github.com/Xilinx/dma_ip_drivers
 
+Following steps need to be run on the machine with JTAG connection to the VPK120 board.
+1. Program Boot image using JTAG
+2. Setup TeraTerm terminal with the settings shown in the figure below. How to identify the teraterm port to use?
+3. Launch xsdb and read SBI_CONTROL register at 0xF1220004 address. This register needs to be set to 0x29 to load 
+the PLD PDI from host. This step is essential to get dma transfer step to load pld pdi using QDMA driver.
+Note: If the JTAG cable is connected to a remote host, use the command "conn -host <host_name or host IP address> 
+before connecting to the board using "ta" command (shown below)
+
 The following steps are an example of how a user may test the qdma_accel_sys design,
 assuming that they've taken this example design through bitstream generation and 
 have a design_wrapper_1_boot.pdi and a pld_with_elf.pdi and are unfamiliar with the driver. 
 The details of these commands and instructions can be found in the QDMA driver documentation; 
 the steps are just listed here for ease of use. 
+
+Please note that the commands provided in this section assumes VPK120 board to a PCIe slot and 
+host has assigned the PCIe slot with a BDF value of 01000.
 
 1. Download or clone the dma_ip_drivers repo from GitHub to the host system
 2. Compile the QDMA driver and applications
@@ -100,15 +177,22 @@ $> dma-ctl qdmab3000 q start idx 1 dir c2h
 12. Transfer the stage two (pld_with_elf.pdi) bitstream to the device to be programmed,
 targeting the SBI FIFO using address 0x102100000
 
-$> dma-to-device -d /dev/qdmab30000-MM-0 -f <stage2.pdi> -s <size> -a 0x20102100000
+$> dma-to-device -d /dev/qdmab3000-MM-0 -f <stage2.pdi> -s <size> -a 0x20102100000
 
 13. (Optional) Perform H2C and C2H MM DMAs to BRAM and H2C ST DMA to the PL
 to verify that the stage two has successfully been programmed to the
 device
 
 // H2C MM DMA to DDR
-$> dma-to-device -d /dev/qdmab30000-MM-0 -f /dev/urandom -s 32 -a 0x60000000000 -c 1
+$> dma-to-device -d /dev/qdmab3000-MM-0 -f /dev/urandom -s 32 -a 0x60000000000 -c 1
 // H2C MM DMA from BRAM
-$> dma-from-device -d /dev/qdmab30000-MM-1 -f frombram.raw -s 32 -a 0x60000000000 -c 1
+$> dma-from-device -d /dev/qdmab3000-MM-1 -f frombram.raw -s 32 -a 0x60000000000 -c 1
 // H2C ST DMA to PL
-$> dma-to-device -d /dev/qdmab30000-ST-2 -f /dev/urandom -s 64
+$> dma-to-device -d /dev/qdmab3000-ST-2 -f /dev/urandom -s 64
+
+References:
+PG347 - https://docs.amd.com/r/en-US/pg347-cpm-dma-bridge?tocId=oTd_ZrdYcOWw7fqmc3hb9g
+QDMA Linux Driver documentation (Master page) - https://xilinx.github.io/dma_ip_drivers/master/QDMA/linux-kernel/html/index.html
+QDMA Driver Source - https://github.com/Xilinx/dma_ip_drivers
+Inter Processor Interrupts - https://docs.amd.com/r/en-US/am011-versal-acap-trm/Inter-Processor-Interrupts
+Address remapping feature with AXI-NoC - https://docs.amd.com/r/en-US/pg313-network-on-chip/Address-Re-mapping

--- a/ced/Xilinx/IPI/Versal_CPM_QDMA_Accel_Sys_Design/changelog.txt
+++ b/ced/Xilinx/IPI/Versal_CPM_QDMA_Accel_Sys_Design/changelog.txt
@@ -1,7 +1,3 @@
-######### Versal CPM Tandem PCIe CED change log ##############
-# 2024.1 Changes 
-- Name Versal_CPM_Tandem_PCIe -> Versal_CPM_Tandem_PCIe_DFX
-- Added checkbox to GUI to enable DFX for 2 small reconfigurable partitions 
-  in the PL
-# 2022.2 Changes 
-- Initial version
+######### Versal CPM5 QDMA Based Acceleration System CED change log ##############
+# 2025.1 Changes 
+- Initial Release

--- a/ced/Xilinx/IPI/Versal_CPM_QDMA_Accel_Sys_Design/run.tcl
+++ b/ced/Xilinx/IPI/Versal_CPM_QDMA_Accel_Sys_Design/run.tcl
@@ -43,6 +43,7 @@ proc createDesign {design_name options} {
     [file normalize "${currentDir}/src/ST_c2h_cmpt.sv"] \
     [file normalize "${currentDir}/src/ipi_cdma_intr.elf"] \
     [file normalize "${currentDir}/src/qdma_accel_sys.bif"] \
+    [file normalize "${currentDir}/README.txt"] \
    ]
    
    import_files -norecurse -fileset $obj $files
@@ -93,5 +94,22 @@ proc createDesign {design_name options} {
    puts "INFO: EP bd generated"
    puts "INFO: design generation completed successfully"
    } 
+   if [regexp "xcvp1202-vsva2785-2MP-e-S" $board_part_name] {
+   set_property SEGMENTED_CONFIGURATION true [current_project]
+   puts "INFO: Project is set to Segmented Configuration flow"
+   source "$currentDir/scripts/design_1_MP_dev.tcl"
+   # Set synthesis property to be non-OOC
+   set_property synth_checkpoint_mode None [get_files $design_name.bd]
+   validate_bd_design
+   puts "INFO: Block design validation completed"
+   save_bd_design
+   puts "INFO: Block design is saved"
+   generate_target all [get_files $design_name.bd]      
+   open_bd_design [get_bd_files $design_name]   
+   regenerate_bd_layout     
+   puts "INFO: File generation for the IPs in the block design is completed"
+   puts "INFO: EP bd generated"
+   puts "INFO: design generation completed successfully"
+   }
    }
 }

--- a/ced/Xilinx/IPI/Versal_CPM_QDMA_Accel_Sys_Design/scripts/design_1_MP_dev.tcl
+++ b/ced/Xilinx/IPI/Versal_CPM_QDMA_Accel_Sys_Design/scripts/design_1_MP_dev.tcl
@@ -1,0 +1,2323 @@
+
+################################################################
+# This is a generated script based on design: design_1
+#
+# Though there are limitations about the generated script,
+# the main purpose of this utility is to make learning
+# IP Integrator Tcl commands easier.
+################################################################
+
+namespace eval _tcl {
+proc get_script_folder {} {
+   set script_path [file normalize [info script]]
+   set script_folder [file dirname $script_path]
+   return $script_folder
+}
+}
+variable script_folder
+set script_folder [_tcl::get_script_folder]
+
+################################################################
+# Check if script is running in correct Vivado version.
+#
+# NOTE - set scripts_vivado_version "" to ignore version check.
+################################################################
+set scripts_vivado_version ""
+#set scripts_vivado_version 2025.1
+set current_vivado_version [version -short]
+
+if { $scripts_vivado_version ne "" && [string first $scripts_vivado_version $current_vivado_version] == -1 } {
+   puts ""
+   common::send_gid_msg -ssname BD::TCL -id 2040 -severity "CRITICAL WARNING" "This script was generated using Vivado <$scripts_vivado_version> without IP versions in the create_bd_cell commands, but is now being run in <$current_vivado_version> of Vivado. There may have been changes to the IP between Vivado <$scripts_vivado_version> and <$current_vivado_version>, which could impact the functionality and configuration of the design."
+
+}
+
+################################################################
+# START
+################################################################
+
+# To test this script, run the following commands from Vivado Tcl console:
+# source design_1_script.tcl
+
+# If there is no project opened, this script will create a
+# project, but make sure you do not have an existing project
+# <./myproj/project_1.xpr> in the current working folder.
+
+set list_projs [get_projects -quiet]
+if { $list_projs eq "" } {
+   create_project project_1 myproj -part xcvp1202-vsva2785-2MHP-e-S
+   set_property BOARD_PART xilinx.com:vpk120:part0:1.2 [current_project]
+   set_property SEGMENTED_CONFIGURATION true [current_project]
+}
+
+
+# CHANGE DESIGN NAME HERE
+#variable design_name
+set design_name design_1
+
+# If you do not already have an existing IP Integrator design open,
+# you can create a design using the following command:
+#    create_bd_design $design_name
+
+# Creating design if needed
+set errMsg ""
+set nRet 0
+
+set cur_design [current_bd_design -quiet]
+set list_cells [get_bd_cells -quiet]
+
+if { ${design_name} eq "" } {
+   # USE CASES:
+   #    1) Design_name not set
+
+   set errMsg "Please set the variable <design_name> to a non-empty value."
+   set nRet 1
+
+} elseif { ${cur_design} ne "" && ${list_cells} eq "" } {
+   # USE CASES:
+   #    2): Current design opened AND is empty AND names same.
+   #    3): Current design opened AND is empty AND names diff; design_name NOT in project.
+   #    4): Current design opened AND is empty AND names diff; design_name exists in project.
+
+   if { $cur_design ne $design_name } {
+      common::send_gid_msg -ssname BD::TCL -id 2001 -severity "INFO" "Changing value of <design_name> from <$design_name> to <$cur_design> since current design is empty."
+      set design_name [get_property NAME $cur_design]
+   }
+   common::send_gid_msg -ssname BD::TCL -id 2002 -severity "INFO" "Constructing design in IPI design <$cur_design>..."
+
+} elseif { ${cur_design} ne "" && $list_cells ne "" && $cur_design eq $design_name } {
+   # USE CASES:
+   #    5) Current design opened AND has components AND same names.
+
+   set errMsg "Design <$design_name> already exists in your project, please set the variable <design_name> to another value."
+   set nRet 1
+} elseif { [get_files -quiet ${design_name}.bd] ne "" } {
+   # USE CASES: 
+   #    6) Current opened design, has components, but diff names, design_name exists in project.
+   #    7) No opened design, design_name exists in project.
+
+   set errMsg "Design <$design_name> already exists in your project, please set the variable <design_name> to another value."
+   set nRet 2
+
+} else {
+   # USE CASES:
+   #    8) No opened design, design_name not in project.
+   #    9) Current opened design, has components, but diff names, design_name not in project.
+
+   common::send_gid_msg -ssname BD::TCL -id 2003 -severity "INFO" "Currently there is no design <$design_name> in project, so creating one..."
+
+   create_bd_design $design_name
+
+   common::send_gid_msg -ssname BD::TCL -id 2004 -severity "INFO" "Making design <$design_name> as current_bd_design."
+   current_bd_design $design_name
+
+}
+
+common::send_gid_msg -ssname BD::TCL -id 2005 -severity "INFO" "Currently the variable <design_name> is equal to \"$design_name\"."
+
+if { $nRet != 0 } {
+   catch {common::send_gid_msg -ssname BD::TCL -id 2006 -severity "ERROR" $errMsg}
+   return $nRet
+}
+
+set bCheckIPsPassed 1
+##################################################################
+# CHECK IPs
+##################################################################
+set bCheckIPs 1
+if { $bCheckIPs == 1 } {
+   set list_check_ips "\ 
+xilinx.com:ip:axi_noc:*\
+xilinx.com:ip:versal_cips:*\
+xilinx.com:ip:axi_cdma:*\
+xilinx.com:ip:proc_sys_reset:*\
+xilinx.com:ip:smartconnect:*\
+xilinx.com:ip:emb_fifo_gen:*\
+xilinx.com:ip:axis_ila:*\
+"
+
+   set list_ips_missing ""
+   common::send_gid_msg -ssname BD::TCL -id 2011 -severity "INFO" "Checking if the following IPs exist in the project's IP catalog: $list_check_ips ."
+
+   foreach ip_vlnv $list_check_ips {
+      set ip_obj [get_ipdefs -all $ip_vlnv]
+      if { $ip_obj eq "" } {
+         lappend list_ips_missing $ip_vlnv
+      }
+   }
+
+   if { $list_ips_missing ne "" } {
+      catch {common::send_gid_msg -ssname BD::TCL -id 2012 -severity "ERROR" "The following IPs are not found in the IP Catalog:\n  $list_ips_missing\n\nResolution: Please add the repository containing the IP(s) to the project." }
+      set bCheckIPsPassed 0
+   }
+
+}
+
+if { $bCheckIPsPassed != 1 } {
+  common::send_gid_msg -ssname BD::TCL -id 2023 -severity "WARNING" "Will not continue with creation of design due to the error(s) above."
+  return 3
+}
+
+##################################################################
+# DESIGN PROCs
+##################################################################
+
+
+
+# Procedure to create entire design; Provide argument to make
+# procedure reusable. If parentCell is "", will use root.
+proc create_root_design { parentCell } {
+
+  variable script_folder
+  variable design_name
+
+  if { $parentCell eq "" } {
+     set parentCell [get_bd_cells /]
+  }
+
+  # Get object for parentCell
+  set parentObj [get_bd_cells $parentCell]
+  if { $parentObj == "" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2090 -severity "ERROR" "Unable to find parent cell <$parentCell>!"}
+     return
+  }
+
+  # Make sure parentObj is hier blk
+  set parentType [get_property TYPE $parentObj]
+  if { $parentType ne "hier" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2091 -severity "ERROR" "Parent <$parentObj> has TYPE = <$parentType>. Expected to be <hier>."}
+     return
+  }
+
+  # Save current instance; Restore later
+  set oldCurInst [current_bd_instance .]
+
+  # Set parent object as current
+  current_bd_instance $parentObj
+
+
+  # Create interface ports
+  set M_AXIL [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:aximm_rtl:1.0 M_AXIL ]
+  set_property -dict [ list \
+   CONFIG.ADDR_WIDTH {42} \
+   CONFIG.DATA_WIDTH {32} \
+   CONFIG.HAS_BURST {0} \
+   CONFIG.HAS_CACHE {0} \
+   CONFIG.HAS_LOCK {0} \
+   CONFIG.HAS_PROT {1} \
+   CONFIG.HAS_QOS {0} \
+   CONFIG.HAS_REGION {0} \
+   CONFIG.NUM_READ_OUTSTANDING {1} \
+   CONFIG.NUM_WRITE_OUTSTANDING {1} \
+   CONFIG.PROTOCOL {AXI4LITE} \
+   ] $M_AXIL
+
+  set PCIE0_GT_0 [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:gt_rtl:1.0 PCIE0_GT_0 ]
+
+  set dma0_axis_c2h_dmawr_0 [ create_bd_intf_port -mode Master -vlnv xilinx.com:display_eqdma:axis_c2h_dmawr_rtl:1.0 dma0_axis_c2h_dmawr_0 ]
+
+  set dma0_axis_c2h_status_0 [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:qdma_c2h_status_rtl:1.0 dma0_axis_c2h_status_0 ]
+
+  set dma0_dsc_crdt_in_0 [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:qdma_dsc_crdt_in_rtl:1.0 dma0_dsc_crdt_in_0 ]
+
+  set dma0_m_axis_h2c_0 [ create_bd_intf_port -mode Master -vlnv xilinx.com:display_eqdma:m_axis_h2c_rtl:1.0 dma0_m_axis_h2c_0 ]
+
+  set dma0_qsts_out_0 [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:eqdma_qsts_rtl:1.0 dma0_qsts_out_0 ]
+
+  set dma0_s_axis_c2h_0 [ create_bd_intf_port -mode Slave -vlnv xilinx.com:display_eqdma:s_axis_c2h_rtl:1.0 dma0_s_axis_c2h_0 ]
+
+  set dma0_s_axis_c2h_cmpt_0 [ create_bd_intf_port -mode Slave -vlnv xilinx.com:display_eqdma:s_axis_c2h_cmpt_rtl:1.0 dma0_s_axis_c2h_cmpt_0 ]
+
+  set dma0_st_rx_msg_0 [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:axis_rtl:1.0 dma0_st_rx_msg_0 ]
+  set_property -dict [ list \
+   CONFIG.FREQ_HZ {249997498} \
+   ] $dma0_st_rx_msg_0
+
+  set dma0_tm_dsc_sts_0 [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:qdma_tm_dsc_sts_rtl:1.0 dma0_tm_dsc_sts_0 ]
+
+  set gt_refclk0_0 [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 gt_refclk0_0 ]
+
+  set usr_flr_0 [ create_bd_intf_port -mode Slave -vlnv xilinx.com:display_eqdma:usr_flr_rtl:1.0 usr_flr_0 ]
+
+  set usr_irq_0 [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:qdma_usr_irq_rtl:1.0 usr_irq_0 ]
+
+  set sys_clk0_0 [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 sys_clk0_0 ]
+  set_property -dict [ list \
+   CONFIG.FREQ_HZ {200321000} \
+   ] $sys_clk0_0
+
+  set CH0_LPDDR4_0_0 [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:lpddr4_rtl:1.0 CH0_LPDDR4_0_0 ]
+
+  set CH1_LPDDR4_0_0 [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:lpddr4_rtl:1.0 CH1_LPDDR4_0_0 ]
+
+  set sys_clk0_1 [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 sys_clk0_1 ]
+  set_property -dict [ list \
+   CONFIG.FREQ_HZ {196464000} \
+   ] $sys_clk0_1
+
+  set sys_clk0_2 [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 sys_clk0_2 ]
+  set_property -dict [ list \
+   CONFIG.FREQ_HZ {200321000} \
+   ] $sys_clk0_2
+
+  set CH0_LPDDR4_0_1 [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:lpddr4_rtl:1.0 CH0_LPDDR4_0_1 ]
+
+  set CH1_LPDDR4_0_1 [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:lpddr4_rtl:1.0 CH1_LPDDR4_0_1 ]
+
+  set CH0_LPDDR4_0_2 [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:lpddr4_rtl:1.0 CH0_LPDDR4_0_2 ]
+
+  set CH1_LPDDR4_0_2 [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:lpddr4_rtl:1.0 CH1_LPDDR4_0_2 ]
+
+  set ps_pl_axil [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:aximm_rtl:1.0 ps_pl_axil ]
+  set_property -dict [ list \
+   CONFIG.ADDR_WIDTH {42} \
+   CONFIG.DATA_WIDTH {32} \
+   CONFIG.PROTOCOL {AXI4LITE} \
+   ] $ps_pl_axil
+
+  set dma0_c2h_byp_in_mm_1_0 [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dma0_c2h_byp_in_mm_1_0 ]
+
+  set dma0_c2h_byp_in_mm_0_0 [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dma0_c2h_byp_in_mm_0_0 ]
+
+  set dma0_c2h_byp_in_st_csh_0 [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dma0_c2h_byp_in_st_csh_0 ]
+
+  set dma0_c2h_byp_out_0 [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:qdma_dsc_byp_rtl:1.0 dma0_c2h_byp_out_0 ]
+
+
+  # Create ports
+  set cpm_cor_irq_0 [ create_bd_port -dir O -type intr cpm_cor_irq_0 ]
+  set cpm_irq0_0 [ create_bd_port -dir I -type intr cpm_irq0_0 ]
+  set cpm_irq1_0 [ create_bd_port -dir I -type intr cpm_irq1_0 ]
+  set cpm_misc_irq_0 [ create_bd_port -dir O -type intr cpm_misc_irq_0 ]
+  set cpm_uncor_irq_0 [ create_bd_port -dir O -type intr cpm_uncor_irq_0 ]
+  set dma0_axi_aresetn_0 [ create_bd_port -dir O -type rst dma0_axi_aresetn_0 ]
+  set dma0_intrfc_resetn_0 [ create_bd_port -dir I -type rst dma0_intrfc_resetn_0 ]
+  set pcie0_user_clk_0 [ create_bd_port -dir O -type clk pcie0_user_clk_0 ]
+  set_property -dict [ list \
+   CONFIG.ASSOCIATED_BUSIF {M_AXIL:ps_pl_axil} \
+   CONFIG.ASSOCIATED_RESET {dma0_axi_aresetn_0} \
+ ] $pcie0_user_clk_0
+  set cdma_introut_0 [ create_bd_port -dir O -type intr cdma_introut_0 ]
+
+  # Create instance: axi_noc_0, and set properties
+  set axi_noc_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_noc axi_noc_0 ]
+  set_property -dict [list \
+    CONFIG.CONTROLLERTYPE {LPDDR4_SDRAM} \
+    CONFIG.MC0_CONFIG_NUM {config26} \
+    CONFIG.MC0_FLIPPED_PINOUT {true} \
+    CONFIG.MC1_CONFIG_NUM {config26} \
+    CONFIG.MC2_CONFIG_NUM {config26} \
+    CONFIG.MC3_CONFIG_NUM {config26} \
+    CONFIG.MC_ADDR_WIDTH {6} \
+    CONFIG.MC_BURST_LENGTH {16} \
+    CONFIG.MC_CASLATENCY {36} \
+    CONFIG.MC_CASWRITELATENCY {18} \
+    CONFIG.MC_CH0_LP4_CHA_ENABLE {true} \
+    CONFIG.MC_CH0_LP4_CHB_ENABLE {true} \
+    CONFIG.MC_CH1_LP4_CHA_ENABLE {true} \
+    CONFIG.MC_CH1_LP4_CHB_ENABLE {true} \
+    CONFIG.MC_CHANNEL_INTERLEAVING {true} \
+    CONFIG.MC_CHAN_REGION0 {DDR_CH1} \
+    CONFIG.MC_CHAN_REGION1 {DDR_CH1_1} \
+    CONFIG.MC_CH_INTERLEAVING_SIZE {512_Bytes} \
+    CONFIG.MC_CKE_WIDTH {0} \
+    CONFIG.MC_CK_WIDTH {0} \
+    CONFIG.MC_COMPONENT_DENSITY {16Gb} \
+    CONFIG.MC_COMPONENT_WIDTH {x32} \
+    CONFIG.MC_CONFIG_NUM {config26} \
+    CONFIG.MC_DATAWIDTH {32} \
+    CONFIG.MC_DM_WIDTH {4} \
+    CONFIG.MC_DQS_WIDTH {4} \
+    CONFIG.MC_DQ_WIDTH {32} \
+    CONFIG.MC_ECC {false} \
+    CONFIG.MC_ECC_SCRUB_SIZE {4096} \
+    CONFIG.MC_F1_CASLATENCY {36} \
+    CONFIG.MC_F1_CASWRITELATENCY {18} \
+    CONFIG.MC_F1_LPDDR4_MR1 {0x0000} \
+    CONFIG.MC_F1_LPDDR4_MR11 {0x0000} \
+    CONFIG.MC_F1_LPDDR4_MR13 {0x00C0} \
+    CONFIG.MC_F1_LPDDR4_MR2 {0x0000} \
+    CONFIG.MC_F1_LPDDR4_MR22 {0x0000} \
+    CONFIG.MC_F1_LPDDR4_MR3 {0x0000} \
+    CONFIG.MC_F1_TCCD_L {0} \
+    CONFIG.MC_F1_TCCD_L_MIN {0} \
+    CONFIG.MC_F1_TFAW {30000} \
+    CONFIG.MC_F1_TFAWMIN {30000} \
+    CONFIG.MC_F1_TMOD {0} \
+    CONFIG.MC_F1_TMOD_MIN {0} \
+    CONFIG.MC_F1_TMRD {14000} \
+    CONFIG.MC_F1_TMRDMIN {14000} \
+    CONFIG.MC_F1_TMRW {10000} \
+    CONFIG.MC_F1_TMRWMIN {10000} \
+    CONFIG.MC_F1_TRAS {42000} \
+    CONFIG.MC_F1_TRASMIN {42000} \
+    CONFIG.MC_F1_TRCD {18000} \
+    CONFIG.MC_F1_TRCDMIN {18000} \
+    CONFIG.MC_F1_TRPAB {21000} \
+    CONFIG.MC_F1_TRPABMIN {21000} \
+    CONFIG.MC_F1_TRPPB {18000} \
+    CONFIG.MC_F1_TRPPBMIN {18000} \
+    CONFIG.MC_F1_TRRD {7500} \
+    CONFIG.MC_F1_TRRDMIN {7500} \
+    CONFIG.MC_F1_TRRD_L {0} \
+    CONFIG.MC_F1_TRRD_L_MIN {0} \
+    CONFIG.MC_F1_TRRD_S {0} \
+    CONFIG.MC_F1_TRRD_S_MIN {0} \
+    CONFIG.MC_F1_TWR {18000} \
+    CONFIG.MC_F1_TWRMIN {18000} \
+    CONFIG.MC_F1_TWTR {10000} \
+    CONFIG.MC_F1_TWTRMIN {10000} \
+    CONFIG.MC_F1_TWTR_L {0} \
+    CONFIG.MC_F1_TWTR_L_MIN {0} \
+    CONFIG.MC_F1_TWTR_S {0} \
+    CONFIG.MC_F1_TWTR_S_MIN {0} \
+    CONFIG.MC_F1_TZQLAT {30000} \
+    CONFIG.MC_F1_TZQLATMIN {30000} \
+    CONFIG.MC_INPUTCLK0_PERIOD {4992} \
+    CONFIG.MC_IP_TIMEPERIOD1 {512} \
+    CONFIG.MC_LP4_CA_A_WIDTH {6} \
+    CONFIG.MC_LP4_CA_B_WIDTH {6} \
+    CONFIG.MC_LP4_CKE_A_WIDTH {1} \
+    CONFIG.MC_LP4_CKE_B_WIDTH {1} \
+    CONFIG.MC_LP4_CKT_A_WIDTH {1} \
+    CONFIG.MC_LP4_CKT_B_WIDTH {1} \
+    CONFIG.MC_LP4_CS_A_WIDTH {1} \
+    CONFIG.MC_LP4_CS_B_WIDTH {1} \
+    CONFIG.MC_LP4_DMI_A_WIDTH {2} \
+    CONFIG.MC_LP4_DMI_B_WIDTH {2} \
+    CONFIG.MC_LP4_DQS_A_WIDTH {2} \
+    CONFIG.MC_LP4_DQS_B_WIDTH {2} \
+    CONFIG.MC_LP4_DQ_A_WIDTH {16} \
+    CONFIG.MC_LP4_DQ_B_WIDTH {16} \
+    CONFIG.MC_LP4_RESETN_WIDTH {1} \
+    CONFIG.MC_MEMORY_SPEEDGRADE {LPDDR4-4267} \
+    CONFIG.MC_MEMORY_TIMEPERIOD0 {512} \
+    CONFIG.MC_NO_CHANNELS {Dual} \
+    CONFIG.MC_ODTLon {8} \
+    CONFIG.MC_ODT_WIDTH {0} \
+    CONFIG.MC_PER_RD_INTVL {0} \
+    CONFIG.MC_PRE_DEF_ADDR_MAP_SEL {ROW_COLUMN_BANK} \
+    CONFIG.MC_SHARED_SEGMENTS {0} \
+    CONFIG.MC_TCCD {8} \
+    CONFIG.MC_TCCD_L {0} \
+    CONFIG.MC_TCCD_L_MIN {0} \
+    CONFIG.MC_TCKE {15} \
+    CONFIG.MC_TCKEMIN {15} \
+    CONFIG.MC_TDQS2DQ_MAX {800} \
+    CONFIG.MC_TDQS2DQ_MIN {200} \
+    CONFIG.MC_TDQSCK_MAX {3500} \
+    CONFIG.MC_TFAW {30000} \
+    CONFIG.MC_TFAWMIN {30000} \
+    CONFIG.MC_TMOD {0} \
+    CONFIG.MC_TMOD_MIN {0} \
+    CONFIG.MC_TMRD {14000} \
+    CONFIG.MC_TMRDMIN {14000} \
+    CONFIG.MC_TMRD_div4 {10} \
+    CONFIG.MC_TMRD_nCK {28} \
+    CONFIG.MC_TMRW {10000} \
+    CONFIG.MC_TMRWMIN {10000} \
+    CONFIG.MC_TMRW_div4 {10} \
+    CONFIG.MC_TMRW_nCK {20} \
+    CONFIG.MC_TODTon_MIN {3} \
+    CONFIG.MC_TOSCO {40000} \
+    CONFIG.MC_TOSCOMIN {40000} \
+    CONFIG.MC_TOSCO_nCK {79} \
+    CONFIG.MC_TPBR2PBR {90000} \
+    CONFIG.MC_TPBR2PBRMIN {90000} \
+    CONFIG.MC_TRAS {42000} \
+    CONFIG.MC_TRASMIN {42000} \
+    CONFIG.MC_TRAS_nCK {83} \
+    CONFIG.MC_TRC {63000} \
+    CONFIG.MC_TRCD {18000} \
+    CONFIG.MC_TRCDMIN {18000} \
+    CONFIG.MC_TRCD_nCK {36} \
+    CONFIG.MC_TRCMIN {0} \
+    CONFIG.MC_TREFI {3904000} \
+    CONFIG.MC_TREFIPB {488000} \
+    CONFIG.MC_TRFC {0} \
+    CONFIG.MC_TRFCAB {280000} \
+    CONFIG.MC_TRFCABMIN {280000} \
+    CONFIG.MC_TRFCMIN {0} \
+    CONFIG.MC_TRFCPB {140000} \
+    CONFIG.MC_TRFCPBMIN {140000} \
+    CONFIG.MC_TRP {0} \
+    CONFIG.MC_TRPAB {21000} \
+    CONFIG.MC_TRPABMIN {21000} \
+    CONFIG.MC_TRPAB_nCK {42} \
+    CONFIG.MC_TRPMIN {0} \
+    CONFIG.MC_TRPPB {18000} \
+    CONFIG.MC_TRPPBMIN {18000} \
+    CONFIG.MC_TRPPB_nCK {36} \
+    CONFIG.MC_TRPRE {1.8} \
+    CONFIG.MC_TRRD {7500} \
+    CONFIG.MC_TRRDMIN {7500} \
+    CONFIG.MC_TRRD_L {0} \
+    CONFIG.MC_TRRD_L_MIN {0} \
+    CONFIG.MC_TRRD_S {0} \
+    CONFIG.MC_TRRD_S_MIN {0} \
+    CONFIG.MC_TRRD_nCK {15} \
+    CONFIG.MC_TWPRE {1.8} \
+    CONFIG.MC_TWPST {0.4} \
+    CONFIG.MC_TWR {18000} \
+    CONFIG.MC_TWRMIN {18000} \
+    CONFIG.MC_TWR_nCK {36} \
+    CONFIG.MC_TWTR {10000} \
+    CONFIG.MC_TWTRMIN {10000} \
+    CONFIG.MC_TWTR_L {0} \
+    CONFIG.MC_TWTR_S {0} \
+    CONFIG.MC_TWTR_S_MIN {0} \
+    CONFIG.MC_TWTR_nCK {20} \
+    CONFIG.MC_TXP {15} \
+    CONFIG.MC_TXPMIN {15} \
+    CONFIG.MC_TXPR {0} \
+    CONFIG.MC_TZQCAL {1000000} \
+    CONFIG.MC_TZQCAL_div4 {489} \
+    CONFIG.MC_TZQCS_ITVL {0} \
+    CONFIG.MC_TZQLAT {30000} \
+    CONFIG.MC_TZQLATMIN {30000} \
+    CONFIG.MC_TZQLAT_div4 {15} \
+    CONFIG.MC_TZQLAT_nCK {59} \
+    CONFIG.MC_TZQ_START_ITVL {1000000000} \
+    CONFIG.MC_USER_DEFINED_ADDRESS_MAP {16RA-3BA-10CA} \
+    CONFIG.MC_XPLL_CLKOUT1_PERIOD {1024} \
+    CONFIG.NUM_CLKS {7} \
+    CONFIG.NUM_MC {1} \
+    CONFIG.NUM_MCP {4} \
+    CONFIG.NUM_MI {0} \
+    CONFIG.NUM_NMI {1} \
+    CONFIG.NUM_SI {6} \
+  ] $axi_noc_0
+
+
+  set_property -dict [ list \
+   CONFIG.DATA_WIDTH {128} \
+   CONFIG.CONNECTIONS {M00_INI {read_bw {500} write_bw {500} initial_boot {true}} MC_3 {read_bw {500} write_bw {500} read_avg_burst {4} write_avg_burst {4} initial_boot {true}}} \
+   CONFIG.DEST_IDS {} \
+   CONFIG.REMAPS {} \
+   CONFIG.NOC_PARAMS {} \
+   CONFIG.CATEGORY {ps_pcie} \
+ ] [get_bd_intf_pins /axi_noc_0/S00_AXI]
+
+  set_property -dict [ list \
+   CONFIG.CONNECTIONS {M00_INI {read_bw {500} write_bw {500} initial_boot {true}} MC_3 {read_bw {500} write_bw {500} read_avg_burst {4} write_avg_burst {4} initial_boot {true}}} \
+   CONFIG.DEST_IDS {} \
+   CONFIG.NOC_PARAMS {} \
+   CONFIG.CATEGORY {ps_cci} \
+ ] [get_bd_intf_pins /axi_noc_0/S01_AXI]
+
+  set_property -dict [ list \
+   CONFIG.CONNECTIONS {M00_INI {read_bw {500} write_bw {500} initial_boot {true}} MC_3 {read_bw {500} write_bw {500} read_avg_burst {4} write_avg_burst {4} initial_boot {true}}} \
+   CONFIG.DEST_IDS {} \
+   CONFIG.NOC_PARAMS {} \
+   CONFIG.CATEGORY {ps_cci} \
+ ] [get_bd_intf_pins /axi_noc_0/S02_AXI]
+
+  set_property -dict [ list \
+   CONFIG.CONNECTIONS {M00_INI {read_bw {500} write_bw {500} initial_boot {true}} MC_3 {read_bw {500} write_bw {500} read_avg_burst {4} write_avg_burst {4} initial_boot {true}}} \
+   CONFIG.DEST_IDS {} \
+   CONFIG.NOC_PARAMS {} \
+   CONFIG.CATEGORY {ps_cci} \
+ ] [get_bd_intf_pins /axi_noc_0/S03_AXI]
+
+  set_property -dict [ list \
+   CONFIG.CONNECTIONS {M00_INI {read_bw {500} write_bw {500} initial_boot {true}} MC_3 {read_bw {500} write_bw {500} read_avg_burst {4} write_avg_burst {4} initial_boot {true}}} \
+   CONFIG.DEST_IDS {} \
+   CONFIG.NOC_PARAMS {} \
+   CONFIG.CATEGORY {ps_cci} \
+ ] [get_bd_intf_pins /axi_noc_0/S04_AXI]
+
+  set_property -dict [ list \
+   CONFIG.CONNECTIONS {M00_INI {read_bw {500} write_bw {500} initial_boot {true}} MC_3 {read_bw {500} write_bw {500} read_avg_burst {4} write_avg_burst {4} initial_boot {true}}} \
+   CONFIG.DEST_IDS {} \
+   CONFIG.NOC_PARAMS {} \
+   CONFIG.CATEGORY {ps_pmc} \
+ ] [get_bd_intf_pins /axi_noc_0/S05_AXI]
+
+  set_property -dict [ list \
+   CONFIG.ASSOCIATED_BUSIF {S00_AXI} \
+ ] [get_bd_pins /axi_noc_0/aclk0]
+
+  set_property -dict [ list \
+   CONFIG.ASSOCIATED_BUSIF {} \
+ ] [get_bd_pins /axi_noc_0/aclk1]
+
+  set_property -dict [ list \
+   CONFIG.ASSOCIATED_BUSIF {S01_AXI} \
+ ] [get_bd_pins /axi_noc_0/aclk2]
+
+  set_property -dict [ list \
+   CONFIG.ASSOCIATED_BUSIF {S02_AXI} \
+ ] [get_bd_pins /axi_noc_0/aclk3]
+
+  set_property -dict [ list \
+   CONFIG.ASSOCIATED_BUSIF {S03_AXI} \
+ ] [get_bd_pins /axi_noc_0/aclk4]
+
+  set_property -dict [ list \
+   CONFIG.ASSOCIATED_BUSIF {S04_AXI} \
+ ] [get_bd_pins /axi_noc_0/aclk5]
+
+  set_property -dict [ list \
+   CONFIG.ASSOCIATED_BUSIF {S05_AXI} \
+ ] [get_bd_pins /axi_noc_0/aclk6]
+
+  # Create instance: versal_cips_0, and set properties
+  set versal_cips_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:versal_cips versal_cips_0 ]
+  set_property -dict [list \
+    CONFIG.BOOT_MODE {Custom} \
+    CONFIG.CLOCK_MODE {Custom} \
+    CONFIG.CPM_CONFIG { \
+      CPM_PCIE0_COPY_PF0_QDMA_ENABLED {0} \
+      CPM_PCIE0_COPY_PF0_SRIOV_QDMA_ENABLED {0} \
+      CPM_PCIE0_DMA_INTF {AXI_MM_and_AXI_Stream} \
+      CPM_PCIE0_DSC_BYPASS_WR {1} \
+      CPM_PCIE0_MAILBOX_ENABLE {0} \
+      CPM_PCIE0_MAX_LINK_SPEED {16.0_GT/s} \
+      CPM_PCIE0_MODES {DMA} \
+      CPM_PCIE0_MODE_SELECTION {Advanced} \
+      CPM_PCIE0_PF0_BAR0_QDMA_64BIT {1} \
+      CPM_PCIE0_PF0_BAR0_QDMA_PREFETCHABLE {1} \
+      CPM_PCIE0_PF0_BAR0_QDMA_TYPE {DMA} \
+      CPM_PCIE0_PF0_BAR0_SRIOV_QDMA_64BIT {0} \
+      CPM_PCIE0_PF0_BAR0_SRIOV_QDMA_PREFETCHABLE {0} \
+      CPM_PCIE0_PF0_BAR0_SRIOV_QDMA_TYPE {AXI_Bridge_Master} \
+      CPM_PCIE0_PF0_BAR2_QDMA_64BIT {1} \
+      CPM_PCIE0_PF0_BAR2_QDMA_AXCACHE {0} \
+      CPM_PCIE0_PF0_BAR2_QDMA_ENABLED {1} \
+      CPM_PCIE0_PF0_BAR2_QDMA_PREFETCHABLE {1} \
+      CPM_PCIE0_PF0_BAR2_QDMA_SCALE {Megabytes} \
+      CPM_PCIE0_PF0_BAR2_QDMA_STEERING {CPM_PCIE_NOC_1} \
+      CPM_PCIE0_PF0_BAR2_SRIOV_QDMA_64BIT {1} \
+      CPM_PCIE0_PF0_BAR2_SRIOV_QDMA_ENABLED {1} \
+      CPM_PCIE0_PF0_BAR2_SRIOV_QDMA_PREFETCHABLE {1} \
+      CPM_PCIE0_PF0_BAR3_QDMA_AXCACHE {0} \
+      CPM_PCIE0_PF0_BAR4_QDMA_64BIT {1} \
+      CPM_PCIE0_PF0_BAR4_QDMA_ENABLED {1} \
+      CPM_PCIE0_PF0_BAR4_QDMA_SCALE {Megabytes} \
+      CPM_PCIE0_PF0_BAR4_QDMA_SIZE {512} \
+      CPM_PCIE0_PF0_DEV_CAP_10B_TAG_EN {1} \
+      CPM_PCIE0_PF0_DEV_CAP_FUNCTION_LEVEL_RESET_CAPABLE {0} \
+      CPM_PCIE0_PF0_PCIEBAR2AXIBAR_QDMA_0 {0x0000020800000000} \
+      CPM_PCIE0_PF0_PCIEBAR2AXIBAR_QDMA_2 {0x0000020100000000} \
+      CPM_PCIE0_PF0_PCIEBAR2AXIBAR_QDMA_4 {0x0000050000000000} \
+      CPM_PCIE0_PF0_PCIEBAR2AXIBAR_SRIOV_QDMA_0 {0x0000020804000000} \
+      CPM_PCIE0_PF0_PCIEBAR2AXIBAR_SRIOV_QDMA_2 {0x0000020180004000} \
+      CPM_PCIE0_PF0_SRIOV_CAP_INITIAL_VF {4} \
+      CPM_PCIE0_PF1_PCIEBAR2AXIBAR_QDMA_0 {0x0000020801000000} \
+      CPM_PCIE0_PF1_PCIEBAR2AXIBAR_QDMA_2 {0x0000020180001000} \
+      CPM_PCIE0_PF1_PCIEBAR2AXIBAR_SRIOV_QDMA_0 {0x0000020805000000} \
+      CPM_PCIE0_PF1_PCIEBAR2AXIBAR_SRIOV_QDMA_2 {0x0000020180005000} \
+      CPM_PCIE0_PF1_SRIOV_CAP_INITIAL_VF {4} \
+      CPM_PCIE0_PF2_PCIEBAR2AXIBAR_QDMA_0 {0x0000020802000000} \
+      CPM_PCIE0_PF2_PCIEBAR2AXIBAR_QDMA_2 {0x0000020180002000} \
+      CPM_PCIE0_PF2_PCIEBAR2AXIBAR_SRIOV_QDMA_0 {0x0000020806000000} \
+      CPM_PCIE0_PF2_PCIEBAR2AXIBAR_SRIOV_QDMA_2 {0x0000020180006000} \
+      CPM_PCIE0_PF2_SRIOV_CAP_INITIAL_VF {4} \
+      CPM_PCIE0_PF3_PCIEBAR2AXIBAR_QDMA_0 {0x0000020803000000} \
+      CPM_PCIE0_PF3_PCIEBAR2AXIBAR_QDMA_2 {0x0000020180003000} \
+      CPM_PCIE0_PF3_PCIEBAR2AXIBAR_SRIOV_QDMA_0 {0x0000020807000000} \
+      CPM_PCIE0_PF3_PCIEBAR2AXIBAR_SRIOV_QDMA_2 {0x0000020180007000} \
+      CPM_PCIE0_PF3_SRIOV_CAP_INITIAL_VF {4} \
+      CPM_PCIE0_PL_LINK_CAP_MAX_LINK_WIDTH {X8} \
+      CPM_PCIE0_SRIOV_CAP_ENABLE {0} \
+      CPM_PCIE0_TL_PF_ENABLE_REG {1} \
+    } \
+    CONFIG.DDR_MEMORY_MODE {Custom} \
+    CONFIG.IO_CONFIG_MODE {Custom} \
+    CONFIG.PS_PL_CONNECTIVITY_MODE {Custom} \
+    CONFIG.PS_PMC_CONFIG { \
+      AURORA_LINE_RATE_GPBS {12.5} \
+      BOOT_MODE {Custom} \
+      BOOT_SECONDARY_PCIE_ENABLE {0} \
+      CLOCK_MODE {Custom} \
+      COHERENCY_MODE {Custom} \
+      CPM_PCIE0_TANDEM {None} \
+      DDR_MEMORY_MODE {Custom} \
+      DEBUG_MODE {Custom} \
+      DESIGN_MODE {1} \
+      DEVICE_INTEGRITY_MODE {Custom} \
+      DIS_AUTO_POL_CHECK {0} \
+      GT_REFCLK_MHZ {156.25} \
+      INIT_CLK_MHZ {125} \
+      INV_POLARITY {0} \
+      IO_CONFIG_MODE {Custom} \
+      JTAG_USERCODE {0x0} \
+      OT_EAM_RESP {SRST} \
+      PCIE_APERTURES_DUAL_ENABLE {0} \
+      PCIE_APERTURES_SINGLE_ENABLE {1} \
+      PERFORMANCE_MODE {Custom} \
+      PL_SEM_GPIO_ENABLE {0} \
+      PMC_ALT_REF_CLK_FREQMHZ {33.333} \
+      PMC_BANK_0_IO_STANDARD {LVCMOS1.8} \
+      PMC_BANK_1_IO_STANDARD {LVCMOS1.8} \
+      PMC_CIPS_MODE {ADVANCE} \
+      PMC_CORE_SUBSYSTEM_LOAD {10} \
+      PMC_CRP_CFU_REF_CTRL_ACT_FREQMHZ {399.996002} \
+      PMC_CRP_CFU_REF_CTRL_DIVISOR0 {3} \
+      PMC_CRP_CFU_REF_CTRL_FREQMHZ {400} \
+      PMC_CRP_CFU_REF_CTRL_SRCSEL {PPLL} \
+      PMC_CRP_DFT_OSC_REF_CTRL_ACT_FREQMHZ {400} \
+      PMC_CRP_DFT_OSC_REF_CTRL_DIVISOR0 {3} \
+      PMC_CRP_DFT_OSC_REF_CTRL_FREQMHZ {400} \
+      PMC_CRP_DFT_OSC_REF_CTRL_SRCSEL {PPLL} \
+      PMC_CRP_EFUSE_REF_CTRL_ACT_FREQMHZ {100.000000} \
+      PMC_CRP_EFUSE_REF_CTRL_FREQMHZ {100.000000} \
+      PMC_CRP_EFUSE_REF_CTRL_SRCSEL {IRO_CLK/4} \
+      PMC_CRP_HSM0_REF_CTRL_ACT_FREQMHZ {33.333000} \
+      PMC_CRP_HSM0_REF_CTRL_DIVISOR0 {36} \
+      PMC_CRP_HSM0_REF_CTRL_FREQMHZ {33.333} \
+      PMC_CRP_HSM0_REF_CTRL_SRCSEL {PPLL} \
+      PMC_CRP_HSM1_REF_CTRL_ACT_FREQMHZ {133.332001} \
+      PMC_CRP_HSM1_REF_CTRL_DIVISOR0 {9} \
+      PMC_CRP_HSM1_REF_CTRL_FREQMHZ {133.333} \
+      PMC_CRP_HSM1_REF_CTRL_SRCSEL {PPLL} \
+      PMC_CRP_I2C_REF_CTRL_ACT_FREQMHZ {100} \
+      PMC_CRP_I2C_REF_CTRL_DIVISOR0 {12} \
+      PMC_CRP_I2C_REF_CTRL_FREQMHZ {100} \
+      PMC_CRP_I2C_REF_CTRL_SRCSEL {PPLL} \
+      PMC_CRP_LSBUS_REF_CTRL_ACT_FREQMHZ {149.998505} \
+      PMC_CRP_LSBUS_REF_CTRL_DIVISOR0 {8} \
+      PMC_CRP_LSBUS_REF_CTRL_FREQMHZ {150} \
+      PMC_CRP_LSBUS_REF_CTRL_SRCSEL {PPLL} \
+      PMC_CRP_NOC_REF_CTRL_ACT_FREQMHZ {999.989990} \
+      PMC_CRP_NOC_REF_CTRL_FREQMHZ {1000} \
+      PMC_CRP_NOC_REF_CTRL_SRCSEL {NPLL} \
+      PMC_CRP_NPI_REF_CTRL_ACT_FREQMHZ {299.997009} \
+      PMC_CRP_NPI_REF_CTRL_DIVISOR0 {4} \
+      PMC_CRP_NPI_REF_CTRL_FREQMHZ {300} \
+      PMC_CRP_NPI_REF_CTRL_SRCSEL {PPLL} \
+      PMC_CRP_NPLL_CTRL_CLKOUTDIV {4} \
+      PMC_CRP_NPLL_CTRL_FBDIV {120} \
+      PMC_CRP_NPLL_CTRL_SRCSEL {REF_CLK} \
+      PMC_CRP_NPLL_TO_XPD_CTRL_DIVISOR0 {4} \
+      PMC_CRP_OSPI_REF_CTRL_ACT_FREQMHZ {200} \
+      PMC_CRP_OSPI_REF_CTRL_DIVISOR0 {4} \
+      PMC_CRP_OSPI_REF_CTRL_FREQMHZ {200} \
+      PMC_CRP_OSPI_REF_CTRL_SRCSEL {PPLL} \
+      PMC_CRP_PL0_REF_CTRL_ACT_FREQMHZ {249.997498} \
+      PMC_CRP_PL0_REF_CTRL_DIVISOR0 {4} \
+      PMC_CRP_PL0_REF_CTRL_FREQMHZ {250} \
+      PMC_CRP_PL0_REF_CTRL_SRCSEL {NPLL} \
+      PMC_CRP_PL1_REF_CTRL_ACT_FREQMHZ {100} \
+      PMC_CRP_PL1_REF_CTRL_DIVISOR0 {3} \
+      PMC_CRP_PL1_REF_CTRL_FREQMHZ {334} \
+      PMC_CRP_PL1_REF_CTRL_SRCSEL {NPLL} \
+      PMC_CRP_PL2_REF_CTRL_ACT_FREQMHZ {100} \
+      PMC_CRP_PL2_REF_CTRL_DIVISOR0 {3} \
+      PMC_CRP_PL2_REF_CTRL_FREQMHZ {334} \
+      PMC_CRP_PL2_REF_CTRL_SRCSEL {NPLL} \
+      PMC_CRP_PL3_REF_CTRL_ACT_FREQMHZ {100} \
+      PMC_CRP_PL3_REF_CTRL_DIVISOR0 {3} \
+      PMC_CRP_PL3_REF_CTRL_FREQMHZ {334} \
+      PMC_CRP_PL3_REF_CTRL_SRCSEL {NPLL} \
+      PMC_CRP_PL5_REF_CTRL_FREQMHZ {400} \
+      PMC_CRP_PPLL_CTRL_CLKOUTDIV {2} \
+      PMC_CRP_PPLL_CTRL_FBDIV {72} \
+      PMC_CRP_PPLL_CTRL_SRCSEL {REF_CLK} \
+      PMC_CRP_PPLL_TO_XPD_CTRL_DIVISOR0 {1} \
+      PMC_CRP_QSPI_REF_CTRL_ACT_FREQMHZ {299.997009} \
+      PMC_CRP_QSPI_REF_CTRL_DIVISOR0 {4} \
+      PMC_CRP_QSPI_REF_CTRL_FREQMHZ {300} \
+      PMC_CRP_QSPI_REF_CTRL_SRCSEL {PPLL} \
+      PMC_CRP_SDIO0_REF_CTRL_ACT_FREQMHZ {200} \
+      PMC_CRP_SDIO0_REF_CTRL_DIVISOR0 {6} \
+      PMC_CRP_SDIO0_REF_CTRL_FREQMHZ {200} \
+      PMC_CRP_SDIO0_REF_CTRL_SRCSEL {PPLL} \
+      PMC_CRP_SDIO1_REF_CTRL_ACT_FREQMHZ {200} \
+      PMC_CRP_SDIO1_REF_CTRL_DIVISOR0 {6} \
+      PMC_CRP_SDIO1_REF_CTRL_FREQMHZ {200} \
+      PMC_CRP_SDIO1_REF_CTRL_SRCSEL {PPLL} \
+      PMC_CRP_SD_DLL_REF_CTRL_ACT_FREQMHZ {1200} \
+      PMC_CRP_SD_DLL_REF_CTRL_DIVISOR0 {1} \
+      PMC_CRP_SD_DLL_REF_CTRL_FREQMHZ {1200} \
+      PMC_CRP_SD_DLL_REF_CTRL_SRCSEL {PPLL} \
+      PMC_CRP_SWITCH_TIMEOUT_CTRL_ACT_FREQMHZ {1.000000} \
+      PMC_CRP_SWITCH_TIMEOUT_CTRL_DIVISOR0 {100} \
+      PMC_CRP_SWITCH_TIMEOUT_CTRL_FREQMHZ {1} \
+      PMC_CRP_SWITCH_TIMEOUT_CTRL_SRCSEL {IRO_CLK/4} \
+      PMC_CRP_SYSMON_REF_CTRL_ACT_FREQMHZ {299.997009} \
+      PMC_CRP_SYSMON_REF_CTRL_FREQMHZ {299.997009} \
+      PMC_CRP_SYSMON_REF_CTRL_SRCSEL {NPI_REF_CLK} \
+      PMC_CRP_TEST_PATTERN_REF_CTRL_ACT_FREQMHZ {200} \
+      PMC_CRP_TEST_PATTERN_REF_CTRL_DIVISOR0 {6} \
+      PMC_CRP_TEST_PATTERN_REF_CTRL_FREQMHZ {200} \
+      PMC_CRP_TEST_PATTERN_REF_CTRL_SRCSEL {PPLL} \
+      PMC_CRP_USB_SUSPEND_CTRL_ACT_FREQMHZ {0.200000} \
+      PMC_CRP_USB_SUSPEND_CTRL_DIVISOR0 {500} \
+      PMC_CRP_USB_SUSPEND_CTRL_FREQMHZ {0.2} \
+      PMC_CRP_USB_SUSPEND_CTRL_SRCSEL {IRO_CLK/4} \
+      PMC_EXTERNAL_TAMPER {{ENABLE 0} {IO {PMC_MIO 12}}} \
+      PMC_EXTERNAL_TAMPER_1 {{ENABLE 0} {IO None}} \
+      PMC_EXTERNAL_TAMPER_2 {{ENABLE 0} {IO None}} \
+      PMC_EXTERNAL_TAMPER_3 {{ENABLE 0} {IO None}} \
+      PMC_GPIO0_MIO_PERIPHERAL {{ENABLE 0} {IO {PMC_MIO 0 .. 25}}} \
+      PMC_GPIO1_MIO_PERIPHERAL {{ENABLE 0} {IO {PMC_MIO 26 .. 51}}} \
+      PMC_GPIO_EMIO_PERIPHERAL_ENABLE {0} \
+      PMC_GPIO_EMIO_WIDTH {64} \
+      PMC_GPIO_EMIO_WIDTH_HDL {64} \
+      PMC_GPI_ENABLE {0} \
+      PMC_GPI_WIDTH {32} \
+      PMC_GPO_ENABLE {0} \
+      PMC_GPO_WIDTH {32} \
+      PMC_HSM0_CLK_ENABLE {1} \
+      PMC_HSM1_CLK_ENABLE {1} \
+      PMC_I2CPMC_PERIPHERAL {{ENABLE 0} {IO {PMC_MIO 2 .. 3}}} \
+      PMC_MIO0 {{AUX_IO 0} {DIRECTION out} {DRIVE_STRENGTH 12mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 1} {SLEW fast} {USAGE Reserved}} \
+      PMC_MIO1 {{AUX_IO 0} {DIRECTION inout} {DRIVE_STRENGTH 12mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 1} {SLEW fast} {USAGE Reserved}} \
+      PMC_MIO10 {{AUX_IO 0} {DIRECTION inout} {DRIVE_STRENGTH 12mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 1} {SLEW fast} {USAGE Reserved}} \
+      PMC_MIO11 {{AUX_IO 0} {DIRECTION inout} {DRIVE_STRENGTH 12mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 1} {SLEW fast} {USAGE Reserved}} \
+      PMC_MIO12 {{AUX_IO 0} {DIRECTION out} {DRIVE_STRENGTH 12mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 1} {SLEW fast} {USAGE Reserved}} \
+      PMC_MIO13 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO14 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO15 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO16 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO17 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO18 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO19 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO2 {{AUX_IO 0} {DIRECTION inout} {DRIVE_STRENGTH 12mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 1} {SLEW fast} {USAGE Reserved}} \
+      PMC_MIO20 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO21 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO22 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO23 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO24 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO25 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO26 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO27 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO28 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO29 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO3 {{AUX_IO 0} {DIRECTION inout} {DRIVE_STRENGTH 12mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 1} {SLEW fast} {USAGE Reserved}} \
+      PMC_MIO30 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO31 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO32 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO33 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO34 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO35 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO36 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO37 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO38 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Reserved}} \
+      PMC_MIO39 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO4 {{AUX_IO 0} {DIRECTION inout} {DRIVE_STRENGTH 12mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 1} {SLEW fast} {USAGE Reserved}} \
+      PMC_MIO40 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO41 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO42 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Reserved}} \
+      PMC_MIO43 {{AUX_IO 0} {DIRECTION out} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 1} {SLEW slow} {USAGE Reserved}} \
+      PMC_MIO44 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO45 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO46 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO47 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO48 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO49 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO5 {{AUX_IO 0} {DIRECTION out} {DRIVE_STRENGTH 12mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 1} {SLEW fast} {USAGE Reserved}} \
+      PMC_MIO50 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO51 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PMC_MIO6 {{AUX_IO 0} {DIRECTION out} {DRIVE_STRENGTH 12mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 1} {SLEW fast} {USAGE Reserved}} \
+      PMC_MIO7 {{AUX_IO 0} {DIRECTION out} {DRIVE_STRENGTH 12mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 1} {SLEW fast} {USAGE Reserved}} \
+      PMC_MIO8 {{AUX_IO 0} {DIRECTION inout} {DRIVE_STRENGTH 12mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 1} {SLEW fast} {USAGE Reserved}} \
+      PMC_MIO9 {{AUX_IO 0} {DIRECTION inout} {DRIVE_STRENGTH 12mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 1} {SLEW fast} {USAGE Reserved}} \
+      PMC_MIO_EN_FOR_PL_PCIE {0} \
+      PMC_MIO_TREE_PERIPHERALS {QSPI#QSPI#QSPI#QSPI#QSPI#QSPI#Loopback Clk#QSPI#QSPI#QSPI#QSPI#QSPI#QSPI##########################PCIE####UART 0#UART 0##################################} \
+      PMC_MIO_TREE_SIGNALS {qspi0_clk#qspi0_io[1]#qspi0_io[2]#qspi0_io[3]#qspi0_io[0]#qspi0_cs_b#qspi_lpbk#qspi1_cs_b#qspi1_io[0]#qspi1_io[1]#qspi1_io[2]#qspi1_io[3]#qspi1_clk##########################reset1_n####rxd#txd##################################}\
+\
+      PMC_NOC_PMC_ADDR_WIDTH {64} \
+      PMC_NOC_PMC_DATA_WIDTH {128} \
+      PMC_OSPI_COHERENCY {0} \
+      PMC_OSPI_PERIPHERAL {{ENABLE 0} {IO {PMC_MIO 0 .. 11}} {MODE Single}} \
+      PMC_OSPI_ROUTE_THROUGH_FPD {0} \
+      PMC_PL_ALT_REF_CLK_FREQMHZ {33.333} \
+      PMC_PMC_NOC_ADDR_WIDTH {64} \
+      PMC_PMC_NOC_DATA_WIDTH {128} \
+      PMC_QSPI_COHERENCY {0} \
+      PMC_QSPI_FBCLK {{ENABLE 1} {IO {PMC_MIO 6}}} \
+      PMC_QSPI_PERIPHERAL_DATA_MODE {x4} \
+      PMC_QSPI_PERIPHERAL_ENABLE {1} \
+      PMC_QSPI_PERIPHERAL_MODE {Dual Parallel} \
+      PMC_QSPI_ROUTE_THROUGH_FPD {0} \
+      PMC_REF_CLK_FREQMHZ {33.333} \
+      PMC_SD0 {{CD_ENABLE 0} {CD_IO {PMC_MIO 24}} {POW_ENABLE 0} {POW_IO {PMC_MIO 17}} {RESET_ENABLE 0} {RESET_IO {PMC_MIO 17}} {WP_ENABLE 0} {WP_IO {PMC_MIO 25}}} \
+      PMC_SD0_COHERENCY {0} \
+      PMC_SD0_DATA_TRANSFER_MODE {4Bit} \
+      PMC_SD0_PERIPHERAL {{CLK_100_SDR_OTAP_DLY 0x00} {CLK_200_SDR_OTAP_DLY 0x00} {CLK_50_DDR_ITAP_DLY 0x00} {CLK_50_DDR_OTAP_DLY 0x00} {CLK_50_SDR_ITAP_DLY 0x00} {CLK_50_SDR_OTAP_DLY 0x00} {ENABLE 0}\
+{IO {PMC_MIO 13 .. 25}}} \
+      PMC_SD0_ROUTE_THROUGH_FPD {0} \
+      PMC_SD0_SLOT_TYPE {SD 2.0} \
+      PMC_SD0_SPEED_MODE {default speed} \
+      PMC_SD1 {{CD_ENABLE 0} {CD_IO {PMC_MIO 2}} {POW_ENABLE 0} {POW_IO {PMC_MIO 12}} {RESET_ENABLE 0} {RESET_IO {PMC_MIO 12}} {WP_ENABLE 0} {WP_IO {PMC_MIO 1}}} \
+      PMC_SD1_COHERENCY {0} \
+      PMC_SD1_DATA_TRANSFER_MODE {4Bit} \
+      PMC_SD1_PERIPHERAL {{CLK_100_SDR_OTAP_DLY 0x00} {CLK_200_SDR_OTAP_DLY 0x00} {CLK_50_DDR_ITAP_DLY 0x00} {CLK_50_DDR_OTAP_DLY 0x00} {CLK_50_SDR_ITAP_DLY 0x00} {CLK_50_SDR_OTAP_DLY 0x00} {ENABLE 0}\
+{IO {PMC_MIO 0 .. 11}}} \
+      PMC_SD1_ROUTE_THROUGH_FPD {0} \
+      PMC_SD1_SLOT_TYPE {SD 2.0} \
+      PMC_SD1_SPEED_MODE {default speed} \
+      PMC_SHOW_CCI_SMMU_SETTINGS {0} \
+      PMC_SMAP_PERIPHERAL {{ENABLE 0} {IO {32 Bit}}} \
+      PMC_TAMPER_EXTMIO_ENABLE {0} \
+      PMC_TAMPER_EXTMIO_ERASE_BBRAM {0} \
+      PMC_TAMPER_EXTMIO_RESPONSE {SYS INTERRUPT} \
+      PMC_TAMPER_GLITCHDETECT_ENABLE {0} \
+      PMC_TAMPER_GLITCHDETECT_ENABLE_1 {0} \
+      PMC_TAMPER_GLITCHDETECT_ENABLE_2 {0} \
+      PMC_TAMPER_GLITCHDETECT_ENABLE_3 {0} \
+      PMC_TAMPER_GLITCHDETECT_ERASE_BBRAM {0} \
+      PMC_TAMPER_GLITCHDETECT_ERASE_BBRAM_1 {0} \
+      PMC_TAMPER_GLITCHDETECT_ERASE_BBRAM_2 {0} \
+      PMC_TAMPER_GLITCHDETECT_ERASE_BBRAM_3 {0} \
+      PMC_TAMPER_GLITCHDETECT_RESPONSE {SYS INTERRUPT} \
+      PMC_TAMPER_GLITCHDETECT_RESPONSE_1 {SYS INTERRUPT} \
+      PMC_TAMPER_GLITCHDETECT_RESPONSE_2 {SYS INTERRUPT} \
+      PMC_TAMPER_GLITCHDETECT_RESPONSE_3 {SYS INTERRUPT} \
+      PMC_TAMPER_JTAGDETECT_ENABLE {0} \
+      PMC_TAMPER_JTAGDETECT_ENABLE_1 {0} \
+      PMC_TAMPER_JTAGDETECT_ENABLE_2 {0} \
+      PMC_TAMPER_JTAGDETECT_ENABLE_3 {0} \
+      PMC_TAMPER_JTAGDETECT_ERASE_BBRAM {0} \
+      PMC_TAMPER_JTAGDETECT_ERASE_BBRAM_1 {0} \
+      PMC_TAMPER_JTAGDETECT_ERASE_BBRAM_2 {0} \
+      PMC_TAMPER_JTAGDETECT_ERASE_BBRAM_3 {0} \
+      PMC_TAMPER_JTAGDETECT_RESPONSE {SYS INTERRUPT} \
+      PMC_TAMPER_JTAGDETECT_RESPONSE_1 {SYS INTERRUPT} \
+      PMC_TAMPER_JTAGDETECT_RESPONSE_2 {SYS INTERRUPT} \
+      PMC_TAMPER_JTAGDETECT_RESPONSE_3 {SYS INTERRUPT} \
+      PMC_TAMPER_SUP_0_31_ENABLE {0} \
+      PMC_TAMPER_SUP_0_31_ERASE_BBRAM {0} \
+      PMC_TAMPER_SUP_0_31_RESPONSE {SYS INTERRUPT} \
+      PMC_TAMPER_TEMPERATURE_ENABLE {0} \
+      PMC_TAMPER_TEMPERATURE_ENABLE_1 {0} \
+      PMC_TAMPER_TEMPERATURE_ENABLE_2 {0} \
+      PMC_TAMPER_TEMPERATURE_ENABLE_3 {0} \
+      PMC_TAMPER_TEMPERATURE_ERASE_BBRAM {0} \
+      PMC_TAMPER_TEMPERATURE_ERASE_BBRAM_1 {0} \
+      PMC_TAMPER_TEMPERATURE_ERASE_BBRAM_2 {0} \
+      PMC_TAMPER_TEMPERATURE_ERASE_BBRAM_3 {0} \
+      PMC_TAMPER_TEMPERATURE_RESPONSE {SYS INTERRUPT} \
+      PMC_TAMPER_TEMPERATURE_RESPONSE_1 {SYS INTERRUPT} \
+      PMC_TAMPER_TEMPERATURE_RESPONSE_2 {SYS INTERRUPT} \
+      PMC_TAMPER_TEMPERATURE_RESPONSE_3 {SYS INTERRUPT} \
+      PMC_USE_CFU_SEU {0} \
+      PMC_USE_NOC_PMC_AXI0 {1} \
+      PMC_USE_NOC_PMC_AXI1 {0} \
+      PMC_USE_NOC_PMC_AXI2 {0} \
+      PMC_USE_NOC_PMC_AXI3 {0} \
+      PMC_USE_PL_PMC_AUX_REF_CLK {0} \
+      PMC_USE_PMC_NOC_AXI0 {1} \
+      PMC_USE_PMC_NOC_AXI1 {0} \
+      PMC_USE_PMC_NOC_AXI2 {0} \
+      PMC_USE_PMC_NOC_AXI3 {0} \
+      PMC_WDT_PERIOD {100} \
+      PMC_WDT_PERIPHERAL {{ENABLE 0} {IO {PMC_MIO 0}}} \
+      POWER_REPORTING_MODE {Custom} \
+      PSPMC_MANUAL_CLK_ENABLE {0} \
+      PS_A72_ACTIVE_BLOCKS {2} \
+      PS_A72_LOAD {90} \
+      PS_BANK_2_IO_STANDARD {LVCMOS1.8} \
+      PS_BANK_3_IO_STANDARD {LVCMOS1.8} \
+      PS_BOARD_INTERFACE {Custom} \
+      PS_CAN0_CLK {{ENABLE 0} {IO {PMC_MIO 0}}} \
+      PS_CAN0_PERIPHERAL {{ENABLE 0} {IO {PMC_MIO 8 .. 9}}} \
+      PS_CAN1_CLK {{ENABLE 0} {IO {PMC_MIO 0}}} \
+      PS_CAN1_PERIPHERAL {{ENABLE 0} {IO {PS_MIO 16 .. 17}}} \
+      PS_CRF_ACPU_CTRL_ACT_FREQMHZ {1399.985962} \
+      PS_CRF_ACPU_CTRL_DIVISOR0 {1} \
+      PS_CRF_ACPU_CTRL_FREQMHZ {1400} \
+      PS_CRF_ACPU_CTRL_SRCSEL {APLL} \
+      PS_CRF_APLL_CTRL_CLKOUTDIV {2} \
+      PS_CRF_APLL_CTRL_FBDIV {84} \
+      PS_CRF_APLL_CTRL_SRCSEL {REF_CLK} \
+      PS_CRF_APLL_TO_XPD_CTRL_DIVISOR0 {4} \
+      PS_CRF_DBG_FPD_CTRL_ACT_FREQMHZ {399.996002} \
+      PS_CRF_DBG_FPD_CTRL_DIVISOR0 {3} \
+      PS_CRF_DBG_FPD_CTRL_FREQMHZ {400} \
+      PS_CRF_DBG_FPD_CTRL_SRCSEL {PPLL} \
+      PS_CRF_DBG_TRACE_CTRL_ACT_FREQMHZ {300} \
+      PS_CRF_DBG_TRACE_CTRL_DIVISOR0 {3} \
+      PS_CRF_DBG_TRACE_CTRL_FREQMHZ {300} \
+      PS_CRF_DBG_TRACE_CTRL_SRCSEL {PPLL} \
+      PS_CRF_FPD_LSBUS_CTRL_ACT_FREQMHZ {149.998505} \
+      PS_CRF_FPD_LSBUS_CTRL_DIVISOR0 {8} \
+      PS_CRF_FPD_LSBUS_CTRL_FREQMHZ {150} \
+      PS_CRF_FPD_LSBUS_CTRL_SRCSEL {PPLL} \
+      PS_CRF_FPD_TOP_SWITCH_CTRL_ACT_FREQMHZ {824.991760} \
+      PS_CRF_FPD_TOP_SWITCH_CTRL_DIVISOR0 {1} \
+      PS_CRF_FPD_TOP_SWITCH_CTRL_FREQMHZ {825} \
+      PS_CRF_FPD_TOP_SWITCH_CTRL_SRCSEL {RPLL} \
+      PS_CRL_CAN0_REF_CTRL_ACT_FREQMHZ {100} \
+      PS_CRL_CAN0_REF_CTRL_DIVISOR0 {12} \
+      PS_CRL_CAN0_REF_CTRL_FREQMHZ {100} \
+      PS_CRL_CAN0_REF_CTRL_SRCSEL {PPLL} \
+      PS_CRL_CAN1_REF_CTRL_ACT_FREQMHZ {100} \
+      PS_CRL_CAN1_REF_CTRL_DIVISOR0 {12} \
+      PS_CRL_CAN1_REF_CTRL_FREQMHZ {100} \
+      PS_CRL_CAN1_REF_CTRL_SRCSEL {PPLL} \
+      PS_CRL_CPM_TOPSW_REF_CTRL_ACT_FREQMHZ {824.991760} \
+      PS_CRL_CPM_TOPSW_REF_CTRL_DIVISOR0 {1} \
+      PS_CRL_CPM_TOPSW_REF_CTRL_FREQMHZ {825} \
+      PS_CRL_CPM_TOPSW_REF_CTRL_SRCSEL {RPLL} \
+      PS_CRL_CPU_R5_CTRL_ACT_FREQMHZ {599.994019} \
+      PS_CRL_CPU_R5_CTRL_DIVISOR0 {2} \
+      PS_CRL_CPU_R5_CTRL_FREQMHZ {600} \
+      PS_CRL_CPU_R5_CTRL_SRCSEL {PPLL} \
+      PS_CRL_DBG_LPD_CTRL_ACT_FREQMHZ {399.996002} \
+      PS_CRL_DBG_LPD_CTRL_DIVISOR0 {3} \
+      PS_CRL_DBG_LPD_CTRL_FREQMHZ {400} \
+      PS_CRL_DBG_LPD_CTRL_SRCSEL {PPLL} \
+      PS_CRL_DBG_TSTMP_CTRL_ACT_FREQMHZ {399.996002} \
+      PS_CRL_DBG_TSTMP_CTRL_DIVISOR0 {3} \
+      PS_CRL_DBG_TSTMP_CTRL_FREQMHZ {400} \
+      PS_CRL_DBG_TSTMP_CTRL_SRCSEL {PPLL} \
+      PS_CRL_GEM0_REF_CTRL_ACT_FREQMHZ {125} \
+      PS_CRL_GEM0_REF_CTRL_DIVISOR0 {4} \
+      PS_CRL_GEM0_REF_CTRL_FREQMHZ {125} \
+      PS_CRL_GEM0_REF_CTRL_SRCSEL {NPLL} \
+      PS_CRL_GEM1_REF_CTRL_ACT_FREQMHZ {125} \
+      PS_CRL_GEM1_REF_CTRL_DIVISOR0 {4} \
+      PS_CRL_GEM1_REF_CTRL_FREQMHZ {125} \
+      PS_CRL_GEM1_REF_CTRL_SRCSEL {NPLL} \
+      PS_CRL_GEM_TSU_REF_CTRL_ACT_FREQMHZ {250} \
+      PS_CRL_GEM_TSU_REF_CTRL_DIVISOR0 {2} \
+      PS_CRL_GEM_TSU_REF_CTRL_FREQMHZ {250} \
+      PS_CRL_GEM_TSU_REF_CTRL_SRCSEL {NPLL} \
+      PS_CRL_I2C0_REF_CTRL_ACT_FREQMHZ {100} \
+      PS_CRL_I2C0_REF_CTRL_DIVISOR0 {12} \
+      PS_CRL_I2C0_REF_CTRL_FREQMHZ {100} \
+      PS_CRL_I2C0_REF_CTRL_SRCSEL {PPLL} \
+      PS_CRL_I2C1_REF_CTRL_ACT_FREQMHZ {100} \
+      PS_CRL_I2C1_REF_CTRL_DIVISOR0 {12} \
+      PS_CRL_I2C1_REF_CTRL_FREQMHZ {100} \
+      PS_CRL_I2C1_REF_CTRL_SRCSEL {PPLL} \
+      PS_CRL_IOU_SWITCH_CTRL_ACT_FREQMHZ {249.997498} \
+      PS_CRL_IOU_SWITCH_CTRL_DIVISOR0 {1} \
+      PS_CRL_IOU_SWITCH_CTRL_FREQMHZ {250} \
+      PS_CRL_IOU_SWITCH_CTRL_SRCSEL {NPLL} \
+      PS_CRL_LPD_LSBUS_CTRL_ACT_FREQMHZ {149.998505} \
+      PS_CRL_LPD_LSBUS_CTRL_DIVISOR0 {8} \
+      PS_CRL_LPD_LSBUS_CTRL_FREQMHZ {150} \
+      PS_CRL_LPD_LSBUS_CTRL_SRCSEL {PPLL} \
+      PS_CRL_LPD_TOP_SWITCH_CTRL_ACT_FREQMHZ {599.994019} \
+      PS_CRL_LPD_TOP_SWITCH_CTRL_DIVISOR0 {2} \
+      PS_CRL_LPD_TOP_SWITCH_CTRL_FREQMHZ {600} \
+      PS_CRL_LPD_TOP_SWITCH_CTRL_SRCSEL {PPLL} \
+      PS_CRL_PSM_REF_CTRL_ACT_FREQMHZ {399.996002} \
+      PS_CRL_PSM_REF_CTRL_DIVISOR0 {3} \
+      PS_CRL_PSM_REF_CTRL_FREQMHZ {400} \
+      PS_CRL_PSM_REF_CTRL_SRCSEL {PPLL} \
+      PS_CRL_RPLL_CTRL_CLKOUTDIV {4} \
+      PS_CRL_RPLL_CTRL_FBDIV {99} \
+      PS_CRL_RPLL_CTRL_SRCSEL {REF_CLK} \
+      PS_CRL_RPLL_TO_XPD_CTRL_DIVISOR0 {1} \
+      PS_CRL_SPI0_REF_CTRL_ACT_FREQMHZ {200} \
+      PS_CRL_SPI0_REF_CTRL_DIVISOR0 {6} \
+      PS_CRL_SPI0_REF_CTRL_FREQMHZ {200} \
+      PS_CRL_SPI0_REF_CTRL_SRCSEL {PPLL} \
+      PS_CRL_SPI1_REF_CTRL_ACT_FREQMHZ {200} \
+      PS_CRL_SPI1_REF_CTRL_DIVISOR0 {6} \
+      PS_CRL_SPI1_REF_CTRL_FREQMHZ {200} \
+      PS_CRL_SPI1_REF_CTRL_SRCSEL {PPLL} \
+      PS_CRL_TIMESTAMP_REF_CTRL_ACT_FREQMHZ {99.999001} \
+      PS_CRL_TIMESTAMP_REF_CTRL_DIVISOR0 {12} \
+      PS_CRL_TIMESTAMP_REF_CTRL_FREQMHZ {100} \
+      PS_CRL_TIMESTAMP_REF_CTRL_SRCSEL {PPLL} \
+      PS_CRL_UART0_REF_CTRL_ACT_FREQMHZ {99.999001} \
+      PS_CRL_UART0_REF_CTRL_DIVISOR0 {12} \
+      PS_CRL_UART0_REF_CTRL_FREQMHZ {100} \
+      PS_CRL_UART0_REF_CTRL_SRCSEL {PPLL} \
+      PS_CRL_UART1_REF_CTRL_ACT_FREQMHZ {100} \
+      PS_CRL_UART1_REF_CTRL_DIVISOR0 {12} \
+      PS_CRL_UART1_REF_CTRL_FREQMHZ {100} \
+      PS_CRL_UART1_REF_CTRL_SRCSEL {PPLL} \
+      PS_CRL_USB0_BUS_REF_CTRL_ACT_FREQMHZ {20} \
+      PS_CRL_USB0_BUS_REF_CTRL_DIVISOR0 {60} \
+      PS_CRL_USB0_BUS_REF_CTRL_FREQMHZ {20} \
+      PS_CRL_USB0_BUS_REF_CTRL_SRCSEL {PPLL} \
+      PS_CRL_USB3_DUAL_REF_CTRL_ACT_FREQMHZ {20} \
+      PS_CRL_USB3_DUAL_REF_CTRL_DIVISOR0 {60} \
+      PS_CRL_USB3_DUAL_REF_CTRL_FREQMHZ {10} \
+      PS_CRL_USB3_DUAL_REF_CTRL_SRCSEL {PPLL} \
+      PS_DDRC_ENABLE {1} \
+      PS_DDR_RAM_HIGHADDR_OFFSET {0x800000000} \
+      PS_DDR_RAM_LOWADDR_OFFSET {0x80000000} \
+      PS_ENET0_MDIO {{ENABLE 0} {IO {PMC_MIO 50 .. 51}}} \
+      PS_ENET0_PERIPHERAL {{ENABLE 0} {IO {PMC_MIO 26 .. 37}}} \
+      PS_ENET1_MDIO {{ENABLE 0} {IO {PMC_MIO 50 .. 51}}} \
+      PS_ENET1_PERIPHERAL {{ENABLE 0} {IO {PMC_MIO 38 .. 49}}} \
+      PS_EN_AXI_STATUS_PORTS {0} \
+      PS_EN_PORTS_CONTROLLER_BASED {0} \
+      PS_EXPAND_CORESIGHT {0} \
+      PS_EXPAND_FPD_SLAVES {0} \
+      PS_EXPAND_GIC {0} \
+      PS_EXPAND_LPD_SLAVES {0} \
+      PS_FPD_INTERCONNECT_LOAD {90} \
+      PS_FTM_CTI_IN0 {0} \
+      PS_FTM_CTI_IN1 {0} \
+      PS_FTM_CTI_IN2 {0} \
+      PS_FTM_CTI_IN3 {0} \
+      PS_FTM_CTI_OUT0 {0} \
+      PS_FTM_CTI_OUT1 {0} \
+      PS_FTM_CTI_OUT2 {0} \
+      PS_FTM_CTI_OUT3 {0} \
+      PS_GEM0_COHERENCY {0} \
+      PS_GEM0_ROUTE_THROUGH_FPD {0} \
+      PS_GEM1_COHERENCY {0} \
+      PS_GEM1_ROUTE_THROUGH_FPD {0} \
+      PS_GEM_TSU {{ENABLE 0} {IO {PS_MIO 24}}} \
+      PS_GEM_TSU_CLK_PORT_PAIR {0} \
+      PS_GEN_IPI0_ENABLE {1} \
+      PS_GEN_IPI0_MASTER {CPM} \
+      PS_GEN_IPI1_ENABLE {1} \
+      PS_GEN_IPI1_MASTER {A72} \
+      PS_GEN_IPI2_ENABLE {0} \
+      PS_GEN_IPI2_MASTER {A72} \
+      PS_GEN_IPI3_ENABLE {0} \
+      PS_GEN_IPI3_MASTER {A72} \
+      PS_GEN_IPI4_ENABLE {0} \
+      PS_GEN_IPI4_MASTER {A72} \
+      PS_GEN_IPI5_ENABLE {0} \
+      PS_GEN_IPI5_MASTER {A72} \
+      PS_GEN_IPI6_ENABLE {0} \
+      PS_GEN_IPI6_MASTER {A72} \
+      PS_GEN_IPI_PMCNOBUF_ENABLE {1} \
+      PS_GEN_IPI_PMCNOBUF_MASTER {PMC} \
+      PS_GEN_IPI_PMC_ENABLE {1} \
+      PS_GEN_IPI_PMC_MASTER {PMC} \
+      PS_GEN_IPI_PSM_ENABLE {1} \
+      PS_GEN_IPI_PSM_MASTER {PSM} \
+      PS_GPIO2_MIO_PERIPHERAL {{ENABLE 0} {IO {PS_MIO 0 .. 25}}} \
+      PS_GPIO_EMIO_PERIPHERAL_ENABLE {0} \
+      PS_GPIO_EMIO_WIDTH {32} \
+      PS_HSDP0_REFCLK {0} \
+      PS_HSDP1_REFCLK {0} \
+      PS_HSDP_EGRESS_TRAFFIC {JTAG} \
+      PS_HSDP_INGRESS_TRAFFIC {JTAG} \
+      PS_HSDP_MODE {NONE} \
+      PS_HSDP_SAME_EGRESS_AS_INGRESS_TRAFFIC {1} \
+      PS_I2C0_PERIPHERAL {{ENABLE 0} {IO {PS_MIO 2 .. 3}}} \
+      PS_I2C1_PERIPHERAL {{ENABLE 0} {IO {PS_MIO 0 .. 1}}} \
+      PS_I2CSYSMON_PERIPHERAL {{ENABLE 0} {IO {PS_MIO 23 .. 24}}} \
+      PS_IRQ_USAGE {{CH0 0} {CH1 0} {CH10 0} {CH11 0} {CH12 0} {CH13 0} {CH14 0} {CH15 0} {CH2 0} {CH3 0} {CH4 0} {CH5 0} {CH6 0} {CH7 0} {CH8 0} {CH9 1}} \
+      PS_LPDMA0_COHERENCY {0} \
+      PS_LPDMA0_ROUTE_THROUGH_FPD {0} \
+      PS_LPDMA1_COHERENCY {0} \
+      PS_LPDMA1_ROUTE_THROUGH_FPD {0} \
+      PS_LPDMA2_COHERENCY {0} \
+      PS_LPDMA2_ROUTE_THROUGH_FPD {0} \
+      PS_LPDMA3_COHERENCY {0} \
+      PS_LPDMA3_ROUTE_THROUGH_FPD {0} \
+      PS_LPDMA4_COHERENCY {0} \
+      PS_LPDMA4_ROUTE_THROUGH_FPD {0} \
+      PS_LPDMA5_COHERENCY {0} \
+      PS_LPDMA5_ROUTE_THROUGH_FPD {0} \
+      PS_LPDMA6_COHERENCY {0} \
+      PS_LPDMA6_ROUTE_THROUGH_FPD {0} \
+      PS_LPDMA7_COHERENCY {0} \
+      PS_LPDMA7_ROUTE_THROUGH_FPD {0} \
+      PS_LPD_DMA_CHANNEL_ENABLE {{CH0 0} {CH1 0} {CH2 0} {CH3 0} {CH4 0} {CH5 0} {CH6 0} {CH7 0}} \
+      PS_LPD_DMA_CH_TZ {{CH0 NonSecure} {CH1 NonSecure} {CH2 NonSecure} {CH3 NonSecure} {CH4 NonSecure} {CH5 NonSecure} {CH6 NonSecure} {CH7 NonSecure}} \
+      PS_LPD_DMA_ENABLE {0} \
+      PS_LPD_INTERCONNECT_LOAD {90} \
+      PS_MIO0 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO1 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO10 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO11 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO12 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO13 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO14 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO15 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO16 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO17 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO18 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO19 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO2 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO20 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO21 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO22 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO23 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO24 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO25 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO3 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO4 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO5 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO6 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO7 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO8 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_MIO9 {{AUX_IO 0} {DIRECTION in} {DRIVE_STRENGTH 8mA} {OUTPUT_DATA default} {PULL pullup} {SCHMITT 0} {SLEW slow} {USAGE Unassigned}} \
+      PS_M_AXI_FPD_DATA_WIDTH {128} \
+      PS_M_AXI_GP4_DATA_WIDTH {128} \
+      PS_M_AXI_LPD_DATA_WIDTH {128} \
+      PS_NOC_PS_CCI_DATA_WIDTH {128} \
+      PS_NOC_PS_NCI_DATA_WIDTH {128} \
+      PS_NOC_PS_PCI_DATA_WIDTH {128} \
+      PS_NOC_PS_PMC_DATA_WIDTH {128} \
+      PS_NUM_F2P0_INTR_INPUTS {1} \
+      PS_NUM_F2P1_INTR_INPUTS {1} \
+      PS_NUM_FABRIC_RESETS {1} \
+      PS_OCM_ACTIVE_BLOCKS {1} \
+      PS_PCIE1_PERIPHERAL_ENABLE {1} \
+      PS_PCIE2_PERIPHERAL_ENABLE {0} \
+      PS_PCIE_EP_RESET1_IO {PMC_MIO 38} \
+      PS_PCIE_EP_RESET2_IO {None} \
+      PS_PCIE_PERIPHERAL_ENABLE {0} \
+      PS_PCIE_RESET {ENABLE 1} \
+      PS_PCIE_ROOT_RESET1_IO {None} \
+      PS_PCIE_ROOT_RESET1_IO_DIR {output} \
+      PS_PCIE_ROOT_RESET1_POLARITY {Active Low} \
+      PS_PCIE_ROOT_RESET2_IO {None} \
+      PS_PCIE_ROOT_RESET2_IO_DIR {output} \
+      PS_PCIE_ROOT_RESET2_POLARITY {Active Low} \
+      PS_PL_CONNECTIVITY_MODE {Custom} \
+      PS_PL_DONE {0} \
+      PS_PL_PASS_AXPROT_VALUE {0} \
+      PS_PMCPL_CLK0_BUF {1} \
+      PS_PMCPL_CLK1_BUF {1} \
+      PS_PMCPL_CLK2_BUF {1} \
+      PS_PMCPL_CLK3_BUF {1} \
+      PS_PMCPL_IRO_CLK_BUF {1} \
+      PS_PMU_PERIPHERAL_ENABLE {0} \
+      PS_PS_ENABLE {0} \
+      PS_PS_NOC_CCI_DATA_WIDTH {128} \
+      PS_PS_NOC_NCI_DATA_WIDTH {128} \
+      PS_PS_NOC_PCI_DATA_WIDTH {128} \
+      PS_PS_NOC_PMC_DATA_WIDTH {128} \
+      PS_PS_NOC_RPU_DATA_WIDTH {128} \
+      PS_R5_ACTIVE_BLOCKS {2} \
+      PS_R5_LOAD {90} \
+      PS_RPU_COHERENCY {0} \
+      PS_SLR_TYPE {master} \
+      PS_SMON_PL_PORTS_ENABLE {0} \
+      PS_SPI0 {{GRP_SS0_ENABLE 0} {GRP_SS0_IO {PMC_MIO 15}} {GRP_SS1_ENABLE 0} {GRP_SS1_IO {PMC_MIO 14}} {GRP_SS2_ENABLE 0} {GRP_SS2_IO {PMC_MIO 13}} {PERIPHERAL_ENABLE 0} {PERIPHERAL_IO {PMC_MIO 12 ..\
+17}}} \
+      PS_SPI1 {{GRP_SS0_ENABLE 0} {GRP_SS0_IO {PS_MIO 9}} {GRP_SS1_ENABLE 0} {GRP_SS1_IO {PS_MIO 8}} {GRP_SS2_ENABLE 0} {GRP_SS2_IO {PS_MIO 7}} {PERIPHERAL_ENABLE 0} {PERIPHERAL_IO {PS_MIO 6 .. 11}}} \
+      PS_S_AXI_ACE_DATA_WIDTH {128} \
+      PS_S_AXI_ACP_DATA_WIDTH {128} \
+      PS_S_AXI_FPD_DATA_WIDTH {128} \
+      PS_S_AXI_GP2_DATA_WIDTH {128} \
+      PS_S_AXI_LPD_DATA_WIDTH {128} \
+      PS_TCM_ACTIVE_BLOCKS {2} \
+      PS_TIE_MJTAG_TCK_TO_GND {1} \
+      PS_TRACE_PERIPHERAL {{ENABLE 0} {IO {PMC_MIO 30 .. 47}}} \
+      PS_TRACE_WIDTH {2Bit} \
+      PS_TRISTATE_INVERTED {1} \
+      PS_TTC0_CLK {{ENABLE 0} {IO {PS_MIO 6}}} \
+      PS_TTC0_PERIPHERAL_ENABLE {0} \
+      PS_TTC0_REF_CTRL_ACT_FREQMHZ {50} \
+      PS_TTC0_REF_CTRL_FREQMHZ {50} \
+      PS_TTC0_WAVEOUT {{ENABLE 0} {IO {PS_MIO 7}}} \
+      PS_TTC1_CLK {{ENABLE 0} {IO {PS_MIO 12}}} \
+      PS_TTC1_PERIPHERAL_ENABLE {0} \
+      PS_TTC1_REF_CTRL_ACT_FREQMHZ {50} \
+      PS_TTC1_REF_CTRL_FREQMHZ {50} \
+      PS_TTC1_WAVEOUT {{ENABLE 0} {IO {PS_MIO 13}}} \
+      PS_TTC2_CLK {{ENABLE 0} {IO {PS_MIO 2}}} \
+      PS_TTC2_PERIPHERAL_ENABLE {0} \
+      PS_TTC2_REF_CTRL_ACT_FREQMHZ {50} \
+      PS_TTC2_REF_CTRL_FREQMHZ {50} \
+      PS_TTC2_WAVEOUT {{ENABLE 0} {IO {PS_MIO 3}}} \
+      PS_TTC3_CLK {{ENABLE 0} {IO {PS_MIO 16}}} \
+      PS_TTC3_PERIPHERAL_ENABLE {0} \
+      PS_TTC3_REF_CTRL_ACT_FREQMHZ {50} \
+      PS_TTC3_REF_CTRL_FREQMHZ {50} \
+      PS_TTC3_WAVEOUT {{ENABLE 0} {IO {PS_MIO 17}}} \
+      PS_TTC_APB_CLK_TTC0_SEL {APB} \
+      PS_TTC_APB_CLK_TTC1_SEL {APB} \
+      PS_TTC_APB_CLK_TTC2_SEL {APB} \
+      PS_TTC_APB_CLK_TTC3_SEL {APB} \
+      PS_UART0_BAUD_RATE {115200} \
+      PS_UART0_PERIPHERAL {{ENABLE 1} {IO {PMC_MIO 42 .. 43}}} \
+      PS_UART0_RTS_CTS {{ENABLE 0} {IO {PS_MIO 2 .. 3}}} \
+      PS_UART1_BAUD_RATE {115200} \
+      PS_UART1_PERIPHERAL {{ENABLE 0} {IO {PMC_MIO 4 .. 5}}} \
+      PS_UART1_RTS_CTS {{ENABLE 0} {IO {PMC_MIO 6 .. 7}}} \
+      PS_UNITS_MODE {Custom} \
+      PS_USB3_PERIPHERAL {{ENABLE 0} {IO {PMC_MIO 13 .. 25}}} \
+      PS_USB_COHERENCY {0} \
+      PS_USB_ROUTE_THROUGH_FPD {0} \
+      PS_USE_ACE_LITE {0} \
+      PS_USE_APU_EVENT_BUS {0} \
+      PS_USE_APU_INTERRUPT {0} \
+      PS_USE_AXI4_EXT_USER_BITS {0} \
+      PS_USE_BSCAN_USER1 {0} \
+      PS_USE_BSCAN_USER2 {0} \
+      PS_USE_BSCAN_USER3 {0} \
+      PS_USE_BSCAN_USER4 {0} \
+      PS_USE_CAPTURE {0} \
+      PS_USE_CLK {0} \
+      PS_USE_DEBUG_TEST {0} \
+      PS_USE_DIFF_RW_CLK_S_AXI_FPD {0} \
+      PS_USE_DIFF_RW_CLK_S_AXI_GP2 {0} \
+      PS_USE_DIFF_RW_CLK_S_AXI_LPD {0} \
+      PS_USE_ENET0_PTP {0} \
+      PS_USE_ENET1_PTP {0} \
+      PS_USE_FIFO_ENET0 {0} \
+      PS_USE_FIFO_ENET1 {0} \
+      PS_USE_FIXED_IO {0} \
+      PS_USE_FPD_AXI_NOC0 {1} \
+      PS_USE_FPD_AXI_NOC1 {0} \
+      PS_USE_FPD_CCI_NOC {1} \
+      PS_USE_FPD_CCI_NOC0 {0} \
+      PS_USE_FPD_CCI_NOC1 {0} \
+      PS_USE_FPD_CCI_NOC2 {0} \
+      PS_USE_FPD_CCI_NOC3 {0} \
+      PS_USE_FTM_GPI {0} \
+      PS_USE_FTM_GPO {0} \
+      PS_USE_HSDP_PL {0} \
+      PS_USE_MJTAG_TCK_TIE_OFF {0} \
+      PS_USE_M_AXI_FPD {1} \
+      PS_USE_M_AXI_LPD {0} \
+      PS_USE_NOC_FPD_AXI0 {0} \
+      PS_USE_NOC_FPD_AXI1 {0} \
+      PS_USE_NOC_FPD_CCI0 {0} \
+      PS_USE_NOC_FPD_CCI1 {0} \
+      PS_USE_NOC_LPD_AXI0 {0} \
+      PS_USE_NOC_PS_PCI_0 {0} \
+      PS_USE_NOC_PS_PMC_0 {0} \
+      PS_USE_NPI_CLK {0} \
+      PS_USE_NPI_RST {0} \
+      PS_USE_PL_FPD_AUX_REF_CLK {0} \
+      PS_USE_PL_LPD_AUX_REF_CLK {0} \
+      PS_USE_PMC {0} \
+      PS_USE_PMCPL_CLK0 {1} \
+      PS_USE_PMCPL_CLK1 {0} \
+      PS_USE_PMCPL_CLK2 {0} \
+      PS_USE_PMCPL_CLK3 {0} \
+      PS_USE_PMCPL_IRO_CLK {0} \
+      PS_USE_PSPL_IRQ_FPD {0} \
+      PS_USE_PSPL_IRQ_LPD {0} \
+      PS_USE_PSPL_IRQ_PMC {0} \
+      PS_USE_PS_NOC_PCI_0 {0} \
+      PS_USE_PS_NOC_PCI_1 {0} \
+      PS_USE_PS_NOC_PMC_0 {0} \
+      PS_USE_PS_NOC_PMC_1 {0} \
+      PS_USE_RPU_EVENT {0} \
+      PS_USE_RPU_INTERRUPT {0} \
+      PS_USE_RTC {0} \
+      PS_USE_SMMU {0} \
+      PS_USE_STARTUP {0} \
+      PS_USE_STM {0} \
+      PS_USE_S_ACP_FPD {0} \
+      PS_USE_S_AXI_ACE {0} \
+      PS_USE_S_AXI_FPD {0} \
+      PS_USE_S_AXI_GP2 {0} \
+      PS_USE_S_AXI_LPD {0} \
+      PS_USE_TRACE_ATB {0} \
+      PS_WDT0_REF_CTRL_ACT_FREQMHZ {100} \
+      PS_WDT0_REF_CTRL_FREQMHZ {100} \
+      PS_WDT0_REF_CTRL_SEL {NONE} \
+      PS_WDT1_REF_CTRL_ACT_FREQMHZ {100} \
+      PS_WDT1_REF_CTRL_FREQMHZ {100} \
+      PS_WDT1_REF_CTRL_SEL {NONE} \
+      PS_WWDT0_CLK {{ENABLE 0} {IO {PMC_MIO 0}}} \
+      PS_WWDT0_PERIPHERAL {{ENABLE 0} {IO {PMC_MIO 0 .. 5}}} \
+      PS_WWDT1_CLK {{ENABLE 0} {IO {PMC_MIO 6}}} \
+      PS_WWDT1_PERIPHERAL {{ENABLE 0} {IO {PMC_MIO 6 .. 11}}} \
+      SEM_ERROR_HANDLE_OPTIONS {Detect & Correct} \
+      SEM_EVENT_LOG_OPTIONS {Log & Notify} \
+      SEM_MEM_BUILT_IN_SELF_TEST {0} \
+      SEM_MEM_ENABLE_ALL_TEST_FEATURE {0} \
+      SEM_MEM_ENABLE_SCAN_AFTER {Immediate Start} \
+      SEM_MEM_GOLDEN_ECC {0} \
+      SEM_MEM_GOLDEN_ECC_SW {0} \
+      SEM_MEM_SCAN {0} \
+      SEM_NPI_BUILT_IN_SELF_TEST {0} \
+      SEM_NPI_ENABLE_ALL_TEST_FEATURE {0} \
+      SEM_NPI_ENABLE_SCAN_AFTER {Immediate Start} \
+      SEM_NPI_GOLDEN_CHECKSUM_SW {0} \
+      SEM_NPI_SCAN {0} \
+      SEM_TIME_INTERVAL_BETWEEN_SCANS {80} \
+      SMON_ALARMS {Set_Alarms_On} \
+      SMON_ENABLE_INT_VOLTAGE_MONITORING {0} \
+      SMON_ENABLE_TEMP_AVERAGING {0} \
+      SMON_INTERFACE_TO_USE {None} \
+      SMON_INT_MEASUREMENT_ALARM_ENABLE {0} \
+      SMON_INT_MEASUREMENT_AVG_ENABLE {0} \
+      SMON_INT_MEASUREMENT_ENABLE {0} \
+      SMON_INT_MEASUREMENT_MODE {0} \
+      SMON_INT_MEASUREMENT_TH_HIGH {0} \
+      SMON_INT_MEASUREMENT_TH_LOW {0} \
+      SMON_MEAS0 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTM_AVCCAUX_202} {SUPPLY_NUM 0}} \
+      SMON_MEAS1 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTM_AVCCAUX_203} {SUPPLY_NUM 0}} \
+      SMON_MEAS10 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTM_AVTT_202} {SUPPLY_NUM 0}} \
+      SMON_MEAS100 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS101 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS102 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS103 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS104 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS105 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS106 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS107 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS108 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS109 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS11 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTM_AVTT_203} {SUPPLY_NUM 0}} \
+      SMON_MEAS110 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS111 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS112 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS113 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS114 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS115 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS116 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS117 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS118 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS119 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS12 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTM_AVTT_204} {SUPPLY_NUM 0}} \
+      SMON_MEAS120 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS121 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS122 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS123 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS124 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS125 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS126 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS127 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS128 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS129 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS13 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTM_AVTT_205} {SUPPLY_NUM 0}} \
+      SMON_MEAS130 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS131 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS132 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS133 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS134 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS135 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS136 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS137 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS138 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS139 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS14 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTM_AVTT_206} {SUPPLY_NUM 0}} \
+      SMON_MEAS140 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS141 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS142 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS143 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS144 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS145 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS146 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS147 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS148 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS149 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS15 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTYP_AVCCAUX_102} {SUPPLY_NUM 0}} \
+      SMON_MEAS150 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS151 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS152 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS153 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS154 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS155 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS156 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS157 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS158 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS159 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS16 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTYP_AVCCAUX_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS160 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103}} \
+      SMON_MEAS161 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103}} \
+      SMON_MEAS162 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCCINT}} \
+      SMON_MEAS163 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCCAUX}} \
+      SMON_MEAS164 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCC_RAM}} \
+      SMON_MEAS165 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCC_SOC}} \
+      SMON_MEAS166 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCC_PSFP}} \
+      SMON_MEAS167 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCC_PSLP}} \
+      SMON_MEAS168 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCCAUX_PMC}} \
+      SMON_MEAS169 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCC_PMC}} \
+      SMON_MEAS17 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTYP_AVCCAUX_104} {SUPPLY_NUM 0}} \
+      SMON_MEAS170 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103}} \
+      SMON_MEAS171 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103}} \
+      SMON_MEAS172 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103}} \
+      SMON_MEAS173 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103}} \
+      SMON_MEAS174 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103}} \
+      SMON_MEAS175 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103}} \
+      SMON_MEAS18 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTYP_AVCCAUX_105} {SUPPLY_NUM 0}} \
+      SMON_MEAS19 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTYP_AVCCAUX_106} {SUPPLY_NUM 0}} \
+      SMON_MEAS2 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTM_AVCCAUX_204} {SUPPLY_NUM 0}} \
+      SMON_MEAS20 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTYP_AVCCAUX_200} {SUPPLY_NUM 0}} \
+      SMON_MEAS21 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTYP_AVCCAUX_201} {SUPPLY_NUM 0}} \
+      SMON_MEAS22 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTYP_AVCC_102} {SUPPLY_NUM 0}} \
+      SMON_MEAS23 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTYP_AVCC_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS24 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTYP_AVCC_104} {SUPPLY_NUM 0}} \
+      SMON_MEAS25 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTYP_AVCC_105} {SUPPLY_NUM 0}} \
+      SMON_MEAS26 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTYP_AVCC_106} {SUPPLY_NUM 0}} \
+      SMON_MEAS27 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTYP_AVCC_200} {SUPPLY_NUM 0}} \
+      SMON_MEAS28 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTYP_AVCC_201} {SUPPLY_NUM 0}} \
+      SMON_MEAS29 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTYP_AVTT_102} {SUPPLY_NUM 0}} \
+      SMON_MEAS3 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTM_AVCCAUX_205} {SUPPLY_NUM 0}} \
+      SMON_MEAS30 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTYP_AVTT_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS31 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTYP_AVTT_104} {SUPPLY_NUM 0}} \
+      SMON_MEAS32 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTYP_AVTT_105} {SUPPLY_NUM 0}} \
+      SMON_MEAS33 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTYP_AVTT_106} {SUPPLY_NUM 0}} \
+      SMON_MEAS34 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTYP_AVTT_200} {SUPPLY_NUM 0}} \
+      SMON_MEAS35 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTYP_AVTT_201} {SUPPLY_NUM 0}} \
+      SMON_MEAS36 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCCAUX} {SUPPLY_NUM 0}} \
+      SMON_MEAS37 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCCAUX_PMC} {SUPPLY_NUM 0}} \
+      SMON_MEAS38 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCCAUX_SMON} {SUPPLY_NUM 0}} \
+      SMON_MEAS39 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCCINT} {SUPPLY_NUM 0}} \
+      SMON_MEAS4 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTM_AVCCAUX_206} {SUPPLY_NUM 0}} \
+      SMON_MEAS40 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 4.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {4 V unipolar}} {NAME VCCO_500} {SUPPLY_NUM 0}} \
+      SMON_MEAS41 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 4.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {4 V unipolar}} {NAME VCCO_501} {SUPPLY_NUM 0}} \
+      SMON_MEAS42 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 4.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {4 V unipolar}} {NAME VCCO_502} {SUPPLY_NUM 0}} \
+      SMON_MEAS43 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 4.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {4 V unipolar}} {NAME VCCO_503} {SUPPLY_NUM 0}} \
+      SMON_MEAS44 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCCO_700} {SUPPLY_NUM 0}} \
+      SMON_MEAS45 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCCO_701} {SUPPLY_NUM 0}} \
+      SMON_MEAS46 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCCO_702} {SUPPLY_NUM 0}} \
+      SMON_MEAS47 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCCO_703} {SUPPLY_NUM 0}} \
+      SMON_MEAS48 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCCO_704} {SUPPLY_NUM 0}} \
+      SMON_MEAS49 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCCO_705} {SUPPLY_NUM 0}} \
+      SMON_MEAS5 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTM_AVCC_202} {SUPPLY_NUM 0}} \
+      SMON_MEAS50 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCCO_706} {SUPPLY_NUM 0}} \
+      SMON_MEAS51 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCCO_707} {SUPPLY_NUM 0}} \
+      SMON_MEAS52 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCCO_708} {SUPPLY_NUM 0}} \
+      SMON_MEAS53 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCCO_709} {SUPPLY_NUM 0}} \
+      SMON_MEAS54 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCCO_710} {SUPPLY_NUM 0}} \
+      SMON_MEAS55 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCCO_711} {SUPPLY_NUM 0}} \
+      SMON_MEAS56 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCCO_712} {SUPPLY_NUM 0}} \
+      SMON_MEAS57 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCC_BATT} {SUPPLY_NUM 0}} \
+      SMON_MEAS58 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCC_PMC} {SUPPLY_NUM 0}} \
+      SMON_MEAS59 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCC_PSFP} {SUPPLY_NUM 0}} \
+      SMON_MEAS6 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTM_AVCC_203} {SUPPLY_NUM 0}} \
+      SMON_MEAS60 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCC_PSLP} {SUPPLY_NUM 0}} \
+      SMON_MEAS61 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 1.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCC_RAM} {SUPPLY_NUM 0}} \
+      SMON_MEAS62 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VCC_SOC} {SUPPLY_NUM 0}} \
+      SMON_MEAS63 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME VP_VN} {SUPPLY_NUM 0}} \
+      SMON_MEAS64 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS65 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS66 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS67 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS68 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS69 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS7 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTM_AVCC_204} {SUPPLY_NUM 0}} \
+      SMON_MEAS70 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS71 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS72 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS73 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS74 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS75 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS76 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS77 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS78 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS79 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS8 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTM_AVCC_205} {SUPPLY_NUM 0}} \
+      SMON_MEAS80 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS81 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS82 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS83 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS84 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS85 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS86 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS87 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS88 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS89 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS9 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE {2 V unipolar}} {NAME GTM_AVCC_206} {SUPPLY_NUM 0}} \
+      SMON_MEAS90 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS91 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS92 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS93 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS94 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS95 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS96 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS97 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS98 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEAS99 {{ALARM_ENABLE 0} {ALARM_LOWER 0.00} {ALARM_UPPER 2.00} {AVERAGE_EN 0} {ENABLE 0} {MODE None} {NAME GT_AVAUX_PKG_103} {SUPPLY_NUM 0}} \
+      SMON_MEASUREMENT_COUNT {64} \
+      SMON_MEASUREMENT_LIST {BANK_VOLTAGE:GTM_AVTT-GTM_AVTT_202,GTM_AVTT_203,GTM_AVTT_204,GTM_AVTT_205,GTM_AVTT_206#GTYP_AVTT-GTYP_AVTT_102,GTYP_AVTT_103,GTYP_AVTT_104,GTYP_AVTT_105,GTYP_AVTT_106,GTYP_AVTT_200,GTYP_AVTT_201#VCC-GTM_AVCC_202,GTM_AVCC_203,GTM_AVCC_204,GTM_AVCC_205,GTM_AVCC_206,GTYP_AVCC_102,GTYP_AVCC_103,GTYP_AVCC_104,GTYP_AVCC_105,GTYP_AVCC_106,GTYP_AVCC_200,GTYP_AVCC_201#VCCAUX-GTM_AVCCAUX_202,GTM_AVCCAUX_203,GTM_AVCCAUX_204,GTM_AVCCAUX_205,GTM_AVCCAUX_206,GTYP_AVCCAUX_102,GTYP_AVCCAUX_103,GTYP_AVCCAUX_104,GTYP_AVCCAUX_105,GTYP_AVCCAUX_106,GTYP_AVCCAUX_200,GTYP_AVCCAUX_201#VCCO-VCCO_500,VCCO_501,VCCO_502,VCCO_503,VCCO_700,VCCO_701,VCCO_702,VCCO_703,VCCO_704,VCCO_705,VCCO_706,VCCO_707,VCCO_708,VCCO_709,VCCO_710,VCCO_711,VCCO_712|DEDICATED_PAD:VP-VP_VN|SUPPLY_VOLTAGE:VCC-VCC_BATT,VCC_PMC,VCC_PSFP,VCC_PSLP,VCC_RAM,VCC_SOC#VCCAUX-VCCAUX,VCCAUX_PMC,VCCAUX_SMON#VCCINT-VCCINT}\
+\
+      SMON_OT {{THRESHOLD_LOWER 70} {THRESHOLD_UPPER 125}} \
+      SMON_PMBUS_ADDRESS {0x0} \
+      SMON_PMBUS_UNRESTRICTED {0} \
+      SMON_REFERENCE_SOURCE {Internal} \
+      SMON_TEMP_AVERAGING_SAMPLES {0} \
+      SMON_TEMP_THRESHOLD {0} \
+      SMON_USER_TEMP {{THRESHOLD_LOWER 70} {THRESHOLD_UPPER 125} {USER_ALARM_TYPE hysteresis}} \
+      SMON_VAUX_CH0 {{ALARM_ENABLE 0} {ALARM_LOWER 0} {ALARM_UPPER 1} {AVERAGE_EN 0} {ENABLE 0} {IO_N PMC_MIO1_500} {IO_P PMC_MIO0_500} {MODE {1 V unipolar}} {NAME VAUX_CH0} {SUPPLY_NUM 0}} \
+      SMON_VAUX_CH1 {{ALARM_ENABLE 0} {ALARM_LOWER 0} {ALARM_UPPER 1} {AVERAGE_EN 0} {ENABLE 0} {IO_N PMC_MIO1_500} {IO_P PMC_MIO0_500} {MODE {1 V unipolar}} {NAME VAUX_CH1} {SUPPLY_NUM 0}} \
+      SMON_VAUX_CH10 {{ALARM_ENABLE 0} {ALARM_LOWER 0} {ALARM_UPPER 1} {AVERAGE_EN 0} {ENABLE 0} {IO_N PMC_MIO1_500} {IO_P PMC_MIO0_500} {MODE {1 V unipolar}} {NAME VAUX_CH10} {SUPPLY_NUM 0}} \
+      SMON_VAUX_CH11 {{ALARM_ENABLE 0} {ALARM_LOWER 0} {ALARM_UPPER 1} {AVERAGE_EN 0} {ENABLE 0} {IO_N PMC_MIO1_500} {IO_P PMC_MIO0_500} {MODE {1 V unipolar}} {NAME VAUX_CH11} {SUPPLY_NUM 0}} \
+      SMON_VAUX_CH12 {{ALARM_ENABLE 0} {ALARM_LOWER 0} {ALARM_UPPER 1} {AVERAGE_EN 0} {ENABLE 0} {IO_N PMC_MIO1_500} {IO_P PMC_MIO0_500} {MODE {1 V unipolar}} {NAME VAUX_CH12} {SUPPLY_NUM 0}} \
+      SMON_VAUX_CH13 {{ALARM_ENABLE 0} {ALARM_LOWER 0} {ALARM_UPPER 1} {AVERAGE_EN 0} {ENABLE 0} {IO_N PMC_MIO1_500} {IO_P PMC_MIO0_500} {MODE {1 V unipolar}} {NAME VAUX_CH13} {SUPPLY_NUM 0}} \
+      SMON_VAUX_CH14 {{ALARM_ENABLE 0} {ALARM_LOWER 0} {ALARM_UPPER 1} {AVERAGE_EN 0} {ENABLE 0} {IO_N PMC_MIO1_500} {IO_P PMC_MIO0_500} {MODE {1 V unipolar}} {NAME VAUX_CH14} {SUPPLY_NUM 0}} \
+      SMON_VAUX_CH15 {{ALARM_ENABLE 0} {ALARM_LOWER 0} {ALARM_UPPER 1} {AVERAGE_EN 0} {ENABLE 0} {IO_N PMC_MIO1_500} {IO_P PMC_MIO0_500} {MODE {1 V unipolar}} {NAME VAUX_CH15} {SUPPLY_NUM 0}} \
+      SMON_VAUX_CH2 {{ALARM_ENABLE 0} {ALARM_LOWER 0} {ALARM_UPPER 1} {AVERAGE_EN 0} {ENABLE 0} {IO_N PMC_MIO1_500} {IO_P PMC_MIO0_500} {MODE {1 V unipolar}} {NAME VAUX_CH2} {SUPPLY_NUM 0}} \
+      SMON_VAUX_CH3 {{ALARM_ENABLE 0} {ALARM_LOWER 0} {ALARM_UPPER 1} {AVERAGE_EN 0} {ENABLE 0} {IO_N PMC_MIO1_500} {IO_P PMC_MIO0_500} {MODE {1 V unipolar}} {NAME VAUX_CH3} {SUPPLY_NUM 0}} \
+      SMON_VAUX_CH4 {{ALARM_ENABLE 0} {ALARM_LOWER 0} {ALARM_UPPER 1} {AVERAGE_EN 0} {ENABLE 0} {IO_N PMC_MIO1_500} {IO_P PMC_MIO0_500} {MODE {1 V unipolar}} {NAME VAUX_CH4} {SUPPLY_NUM 0}} \
+      SMON_VAUX_CH5 {{ALARM_ENABLE 0} {ALARM_LOWER 0} {ALARM_UPPER 1} {AVERAGE_EN 0} {ENABLE 0} {IO_N PMC_MIO1_500} {IO_P PMC_MIO0_500} {MODE {1 V unipolar}} {NAME VAUX_CH5} {SUPPLY_NUM 0}} \
+      SMON_VAUX_CH6 {{ALARM_ENABLE 0} {ALARM_LOWER 0} {ALARM_UPPER 1} {AVERAGE_EN 0} {ENABLE 0} {IO_N PMC_MIO1_500} {IO_P PMC_MIO0_500} {MODE {1 V unipolar}} {NAME VAUX_CH6} {SUPPLY_NUM 0}} \
+      SMON_VAUX_CH7 {{ALARM_ENABLE 0} {ALARM_LOWER 0} {ALARM_UPPER 1} {AVERAGE_EN 0} {ENABLE 0} {IO_N PMC_MIO1_500} {IO_P PMC_MIO0_500} {MODE {1 V unipolar}} {NAME VAUX_CH7} {SUPPLY_NUM 0}} \
+      SMON_VAUX_CH8 {{ALARM_ENABLE 0} {ALARM_LOWER 0} {ALARM_UPPER 1} {AVERAGE_EN 0} {ENABLE 0} {IO_N PMC_MIO1_500} {IO_P PMC_MIO0_500} {MODE {1 V unipolar}} {NAME VAUX_CH8} {SUPPLY_NUM 0}} \
+      SMON_VAUX_CH9 {{ALARM_ENABLE 0} {ALARM_LOWER 0} {ALARM_UPPER 1} {AVERAGE_EN 0} {ENABLE 0} {IO_N PMC_MIO1_500} {IO_P PMC_MIO0_500} {MODE {1 V unipolar}} {NAME VAUX_CH9} {SUPPLY_NUM 0}} \
+      SMON_VAUX_IO_BANK {MIO_BANK0} \
+      SMON_VOLTAGE_AVERAGING_SAMPLES {None} \
+      SPP_PSPMC_FROM_CORE_WIDTH {12000} \
+      SPP_PSPMC_TO_CORE_WIDTH {12000} \
+      SUBPRESET1 {Custom} \
+      USE_UART0_IN_DEVICE_BOOT {0} \
+      preset {None} \
+    } \
+    CONFIG.PS_PMC_CONFIG_APPLIED {1} \
+  ] $versal_cips_0
+
+
+  # Create instance: axi_noc_1, and set properties
+  set axi_noc_1 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_noc axi_noc_1 ]
+  set_property -dict [list \
+    CONFIG.CONTROLLERTYPE {LPDDR4_SDRAM} \
+    CONFIG.MC0_CONFIG_NUM {config26} \
+    CONFIG.MC0_FLIPPED_PINOUT {true} \
+    CONFIG.MC1_CONFIG_NUM {config26} \
+    CONFIG.MC2_CONFIG_NUM {config26} \
+    CONFIG.MC3_CONFIG_NUM {config26} \
+    CONFIG.MC_ADDR_WIDTH {6} \
+    CONFIG.MC_BURST_LENGTH {16} \
+    CONFIG.MC_CASLATENCY {36} \
+    CONFIG.MC_CASWRITELATENCY {18} \
+    CONFIG.MC_CH0_LP4_CHA_ENABLE {true} \
+    CONFIG.MC_CH0_LP4_CHB_ENABLE {true} \
+    CONFIG.MC_CH1_LP4_CHA_ENABLE {true} \
+    CONFIG.MC_CH1_LP4_CHB_ENABLE {true} \
+    CONFIG.MC_CHANNEL_INTERLEAVING {true} \
+    CONFIG.MC_CHAN_REGION0 {DDR_CH2} \
+    CONFIG.MC_CHAN_REGION1 {DDR_CH2_1} \
+    CONFIG.MC_CH_INTERLEAVING_SIZE {512_Bytes} \
+    CONFIG.MC_CKE_WIDTH {0} \
+    CONFIG.MC_CK_WIDTH {0} \
+    CONFIG.MC_COMPONENT_DENSITY {16Gb} \
+    CONFIG.MC_COMPONENT_WIDTH {x32} \
+    CONFIG.MC_CONFIG_NUM {config26} \
+    CONFIG.MC_DATAWIDTH {32} \
+    CONFIG.MC_DM_WIDTH {4} \
+    CONFIG.MC_DQS_WIDTH {4} \
+    CONFIG.MC_DQ_WIDTH {32} \
+    CONFIG.MC_ECC {false} \
+    CONFIG.MC_ECC_SCRUB_SIZE {4096} \
+    CONFIG.MC_F1_CASLATENCY {36} \
+    CONFIG.MC_F1_CASWRITELATENCY {18} \
+    CONFIG.MC_F1_LPDDR4_MR1 {0x0000} \
+    CONFIG.MC_F1_LPDDR4_MR11 {0x0000} \
+    CONFIG.MC_F1_LPDDR4_MR13 {0x00C0} \
+    CONFIG.MC_F1_LPDDR4_MR2 {0x0000} \
+    CONFIG.MC_F1_LPDDR4_MR22 {0x0000} \
+    CONFIG.MC_F1_LPDDR4_MR3 {0x0000} \
+    CONFIG.MC_F1_TCCD_L {0} \
+    CONFIG.MC_F1_TCCD_L_MIN {0} \
+    CONFIG.MC_F1_TFAW {30000} \
+    CONFIG.MC_F1_TFAWMIN {30000} \
+    CONFIG.MC_F1_TMOD {0} \
+    CONFIG.MC_F1_TMOD_MIN {0} \
+    CONFIG.MC_F1_TMRD {14000} \
+    CONFIG.MC_F1_TMRDMIN {14000} \
+    CONFIG.MC_F1_TMRW {10000} \
+    CONFIG.MC_F1_TMRWMIN {10000} \
+    CONFIG.MC_F1_TRAS {42000} \
+    CONFIG.MC_F1_TRASMIN {42000} \
+    CONFIG.MC_F1_TRCD {18000} \
+    CONFIG.MC_F1_TRCDMIN {18000} \
+    CONFIG.MC_F1_TRPAB {21000} \
+    CONFIG.MC_F1_TRPABMIN {21000} \
+    CONFIG.MC_F1_TRPPB {18000} \
+    CONFIG.MC_F1_TRPPBMIN {18000} \
+    CONFIG.MC_F1_TRRD {7500} \
+    CONFIG.MC_F1_TRRDMIN {7500} \
+    CONFIG.MC_F1_TRRD_L {0} \
+    CONFIG.MC_F1_TRRD_L_MIN {0} \
+    CONFIG.MC_F1_TRRD_S {0} \
+    CONFIG.MC_F1_TRRD_S_MIN {0} \
+    CONFIG.MC_F1_TWR {18000} \
+    CONFIG.MC_F1_TWRMIN {18000} \
+    CONFIG.MC_F1_TWTR {10000} \
+    CONFIG.MC_F1_TWTRMIN {10000} \
+    CONFIG.MC_F1_TWTR_L {0} \
+    CONFIG.MC_F1_TWTR_L_MIN {0} \
+    CONFIG.MC_F1_TWTR_S {0} \
+    CONFIG.MC_F1_TWTR_S_MIN {0} \
+    CONFIG.MC_F1_TZQLAT {30000} \
+    CONFIG.MC_F1_TZQLATMIN {30000} \
+    CONFIG.MC_INPUTCLK0_PERIOD {5090} \
+    CONFIG.MC_IP_TIMEPERIOD1 {509} \
+    CONFIG.MC_LP4_CA_A_WIDTH {6} \
+    CONFIG.MC_LP4_CA_B_WIDTH {6} \
+    CONFIG.MC_LP4_CKE_A_WIDTH {1} \
+    CONFIG.MC_LP4_CKE_B_WIDTH {1} \
+    CONFIG.MC_LP4_CKT_A_WIDTH {1} \
+    CONFIG.MC_LP4_CKT_B_WIDTH {1} \
+    CONFIG.MC_LP4_CS_A_WIDTH {1} \
+    CONFIG.MC_LP4_CS_B_WIDTH {1} \
+    CONFIG.MC_LP4_DMI_A_WIDTH {2} \
+    CONFIG.MC_LP4_DMI_B_WIDTH {2} \
+    CONFIG.MC_LP4_DQS_A_WIDTH {2} \
+    CONFIG.MC_LP4_DQS_B_WIDTH {2} \
+    CONFIG.MC_LP4_DQ_A_WIDTH {16} \
+    CONFIG.MC_LP4_DQ_B_WIDTH {16} \
+    CONFIG.MC_LP4_RESETN_WIDTH {1} \
+    CONFIG.MC_MEMORY_SPEEDGRADE {LPDDR4-4267} \
+    CONFIG.MC_MEMORY_TIMEPERIOD0 {509} \
+    CONFIG.MC_NO_CHANNELS {Dual} \
+    CONFIG.MC_ODTLon {8} \
+    CONFIG.MC_ODT_WIDTH {0} \
+    CONFIG.MC_PER_RD_INTVL {0} \
+    CONFIG.MC_PRE_DEF_ADDR_MAP_SEL {ROW_COLUMN_BANK} \
+    CONFIG.MC_SHARED_SEGMENTS {0} \
+    CONFIG.MC_TCCD {8} \
+    CONFIG.MC_TCCD_L {0} \
+    CONFIG.MC_TCCD_L_MIN {0} \
+    CONFIG.MC_TCKE {15} \
+    CONFIG.MC_TCKEMIN {15} \
+    CONFIG.MC_TDQS2DQ_MAX {800} \
+    CONFIG.MC_TDQS2DQ_MIN {200} \
+    CONFIG.MC_TDQSCK_MAX {3500} \
+    CONFIG.MC_TFAW {30000} \
+    CONFIG.MC_TFAWMIN {30000} \
+    CONFIG.MC_TMOD {0} \
+    CONFIG.MC_TMOD_MIN {0} \
+    CONFIG.MC_TMRD {14000} \
+    CONFIG.MC_TMRDMIN {14000} \
+    CONFIG.MC_TMRD_div4 {10} \
+    CONFIG.MC_TMRD_nCK {28} \
+    CONFIG.MC_TMRW {10000} \
+    CONFIG.MC_TMRWMIN {10000} \
+    CONFIG.MC_TMRW_div4 {10} \
+    CONFIG.MC_TMRW_nCK {20} \
+    CONFIG.MC_TODTon_MIN {3} \
+    CONFIG.MC_TOSCO {40000} \
+    CONFIG.MC_TOSCOMIN {40000} \
+    CONFIG.MC_TOSCO_nCK {79} \
+    CONFIG.MC_TPBR2PBR {90000} \
+    CONFIG.MC_TPBR2PBRMIN {90000} \
+    CONFIG.MC_TRAS {42000} \
+    CONFIG.MC_TRASMIN {42000} \
+    CONFIG.MC_TRAS_nCK {83} \
+    CONFIG.MC_TRC {63000} \
+    CONFIG.MC_TRCD {18000} \
+    CONFIG.MC_TRCDMIN {18000} \
+    CONFIG.MC_TRCD_nCK {36} \
+    CONFIG.MC_TRCMIN {0} \
+    CONFIG.MC_TREFI {3904000} \
+    CONFIG.MC_TREFIPB {488000} \
+    CONFIG.MC_TRFC {0} \
+    CONFIG.MC_TRFCAB {280000} \
+    CONFIG.MC_TRFCABMIN {280000} \
+    CONFIG.MC_TRFCMIN {0} \
+    CONFIG.MC_TRFCPB {140000} \
+    CONFIG.MC_TRFCPBMIN {140000} \
+    CONFIG.MC_TRP {0} \
+    CONFIG.MC_TRPAB {21000} \
+    CONFIG.MC_TRPABMIN {21000} \
+    CONFIG.MC_TRPAB_nCK {42} \
+    CONFIG.MC_TRPMIN {0} \
+    CONFIG.MC_TRPPB {18000} \
+    CONFIG.MC_TRPPBMIN {18000} \
+    CONFIG.MC_TRPPB_nCK {36} \
+    CONFIG.MC_TRPRE {1.8} \
+    CONFIG.MC_TRRD {7500} \
+    CONFIG.MC_TRRDMIN {7500} \
+    CONFIG.MC_TRRD_L {0} \
+    CONFIG.MC_TRRD_L_MIN {0} \
+    CONFIG.MC_TRRD_S {0} \
+    CONFIG.MC_TRRD_S_MIN {0} \
+    CONFIG.MC_TRRD_nCK {15} \
+    CONFIG.MC_TWPRE {1.8} \
+    CONFIG.MC_TWPST {0.4} \
+    CONFIG.MC_TWR {18000} \
+    CONFIG.MC_TWRMIN {18000} \
+    CONFIG.MC_TWR_nCK {36} \
+    CONFIG.MC_TWTR {10000} \
+    CONFIG.MC_TWTRMIN {10000} \
+    CONFIG.MC_TWTR_L {0} \
+    CONFIG.MC_TWTR_S {0} \
+    CONFIG.MC_TWTR_S_MIN {0} \
+    CONFIG.MC_TWTR_nCK {20} \
+    CONFIG.MC_TXP {15} \
+    CONFIG.MC_TXPMIN {15} \
+    CONFIG.MC_TXPR {0} \
+    CONFIG.MC_TZQCAL {1000000} \
+    CONFIG.MC_TZQCAL_div4 {492} \
+    CONFIG.MC_TZQCS_ITVL {0} \
+    CONFIG.MC_TZQLAT {30000} \
+    CONFIG.MC_TZQLATMIN {30000} \
+    CONFIG.MC_TZQLAT_div4 {15} \
+    CONFIG.MC_TZQLAT_nCK {59} \
+    CONFIG.MC_TZQ_START_ITVL {1000000000} \
+    CONFIG.MC_USER_DEFINED_ADDRESS_MAP {16RA-3BA-10CA} \
+    CONFIG.MC_XPLL_CLKOUT1_PERIOD {1018} \
+    CONFIG.NUM_CLKS {3} \
+    CONFIG.NUM_MC {1} \
+    CONFIG.NUM_MCP {4} \
+    CONFIG.NUM_MI {2} \
+    CONFIG.NUM_NMI {0} \
+    CONFIG.NUM_SI {1} \
+  ] $axi_noc_1
+
+
+  set_property -dict [ list \
+   CONFIG.CATEGORY {ps_pmc} \
+ ] [get_bd_intf_pins /axi_noc_1/M00_AXI]
+
+  set_property -dict [ list \
+   CONFIG.APERTURES {{0x201_0000_0000 1G}} \
+   CONFIG.CATEGORY {pl} \
+ ] [get_bd_intf_pins /axi_noc_1/M01_AXI]
+
+  set_property -dict [ list \
+   CONFIG.CONNECTIONS {M01_AXI {read_bw {500} write_bw {500} read_avg_burst {4} write_avg_burst {4} initial_boot {false}} M00_AXI {read_bw {1720} write_bw {1720} read_avg_burst {4} write_avg_burst {4} initial_boot {true}} MC_2 {read_bw {500} write_bw {500} read_avg_burst {4} write_avg_burst {4} initial_boot {true}}} \
+   CONFIG.DEST_IDS {M01_AXI:0x80:M00_AXI:0x140} \
+   CONFIG.REMAPS {M00_AXI {{0x201_0030_0000 0xFF30_0000 1M} {0x201_0200_0000 0x1_0200_0000 128K} {0x201_000C_0000 0xFFFC_0000 256K} {0x201_0400_0000 0xFC00_0000 16M} {0x201_0103_0000 0x1_0103_0000 64K} {0x201_0210_0000 0x1_0210_0000 64K} {0x201_0122_0000 0x1_0122_0000 64K}}} \
+   CONFIG.NOC_PARAMS {} \
+   CONFIG.CATEGORY {ps_pcie} \
+ ] [get_bd_intf_pins /axi_noc_1/S00_AXI]
+
+  set_property -dict [ list \
+   CONFIG.ASSOCIATED_BUSIF {M00_AXI} \
+ ] [get_bd_pins /axi_noc_1/aclk0]
+
+  set_property -dict [ list \
+   CONFIG.ASSOCIATED_BUSIF {S00_AXI} \
+ ] [get_bd_pins /axi_noc_1/aclk1]
+
+  set_property -dict [ list \
+   CONFIG.ASSOCIATED_BUSIF {M01_AXI} \
+ ] [get_bd_pins /axi_noc_1/aclk2]
+
+  # Create instance: axi_noc_2, and set properties
+  set axi_noc_2 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_noc axi_noc_2 ]
+  set_property -dict [list \
+    CONFIG.CONTROLLERTYPE {LPDDR4_SDRAM} \
+    CONFIG.MC0_CONFIG_NUM {config26} \
+    CONFIG.MC0_FLIPPED_PINOUT {true} \
+    CONFIG.MC1_CONFIG_NUM {config26} \
+    CONFIG.MC2_CONFIG_NUM {config26} \
+    CONFIG.MC3_CONFIG_NUM {config26} \
+    CONFIG.MC_ADDR_WIDTH {6} \
+    CONFIG.MC_BURST_LENGTH {16} \
+    CONFIG.MC_CASLATENCY {36} \
+    CONFIG.MC_CASWRITELATENCY {18} \
+    CONFIG.MC_CH1_LP4_CHB_ENABLE {true} \
+    CONFIG.MC_CHANNEL_INTERLEAVING {true} \
+    CONFIG.MC_CHAN_REGION0 {DDR_CH3} \
+    CONFIG.MC_CHAN_REGION1 {DDR_CH3_1} \
+    CONFIG.MC_CH_INTERLEAVING_SIZE {512_Bytes} \
+    CONFIG.MC_COMPONENT_DENSITY {16Gb} \
+    CONFIG.MC_COMPONENT_WIDTH {x32} \
+    CONFIG.MC_CONFIG_NUM {config26} \
+    CONFIG.MC_DATAWIDTH {32} \
+    CONFIG.MC_DM_WIDTH {4} \
+    CONFIG.MC_DQS_WIDTH {4} \
+    CONFIG.MC_DQ_WIDTH {32} \
+    CONFIG.MC_ECC {false} \
+    CONFIG.MC_ECC_SCRUB_SIZE {4096} \
+    CONFIG.MC_F1_CASLATENCY {36} \
+    CONFIG.MC_F1_CASWRITELATENCY {18} \
+    CONFIG.MC_F1_LPDDR4_MR1 {0x0000} \
+    CONFIG.MC_F1_LPDDR4_MR11 {0x0000} \
+    CONFIG.MC_F1_LPDDR4_MR13 {0x00C0} \
+    CONFIG.MC_F1_LPDDR4_MR2 {0x0000} \
+    CONFIG.MC_F1_LPDDR4_MR22 {0x0000} \
+    CONFIG.MC_F1_LPDDR4_MR3 {0x0000} \
+    CONFIG.MC_F1_TCCD_L {0} \
+    CONFIG.MC_F1_TCCD_L_MIN {0} \
+    CONFIG.MC_F1_TFAW {30000} \
+    CONFIG.MC_F1_TFAWMIN {30000} \
+    CONFIG.MC_F1_TMOD {0} \
+    CONFIG.MC_F1_TMOD_MIN {0} \
+    CONFIG.MC_F1_TMRD {14000} \
+    CONFIG.MC_F1_TMRDMIN {14000} \
+    CONFIG.MC_F1_TMRW {10000} \
+    CONFIG.MC_F1_TMRWMIN {10000} \
+    CONFIG.MC_F1_TRAS {42000} \
+    CONFIG.MC_F1_TRASMIN {42000} \
+    CONFIG.MC_F1_TRCD {18000} \
+    CONFIG.MC_F1_TRCDMIN {18000} \
+    CONFIG.MC_F1_TRPAB {21000} \
+    CONFIG.MC_F1_TRPABMIN {21000} \
+    CONFIG.MC_F1_TRPPB {18000} \
+    CONFIG.MC_F1_TRPPBMIN {18000} \
+    CONFIG.MC_F1_TRRD {7500} \
+    CONFIG.MC_F1_TRRDMIN {7500} \
+    CONFIG.MC_F1_TRRD_L {0} \
+    CONFIG.MC_F1_TRRD_L_MIN {0} \
+    CONFIG.MC_F1_TRRD_S {0} \
+    CONFIG.MC_F1_TRRD_S_MIN {0} \
+    CONFIG.MC_F1_TWR {18000} \
+    CONFIG.MC_F1_TWRMIN {18000} \
+    CONFIG.MC_F1_TWTR {10000} \
+    CONFIG.MC_F1_TWTRMIN {10000} \
+    CONFIG.MC_F1_TWTR_L {0} \
+    CONFIG.MC_F1_TWTR_L_MIN {0} \
+    CONFIG.MC_F1_TWTR_S {0} \
+    CONFIG.MC_F1_TWTR_S_MIN {0} \
+    CONFIG.MC_F1_TZQLAT {30000} \
+    CONFIG.MC_F1_TZQLATMIN {30000} \
+    CONFIG.MC_INPUTCLK0_PERIOD {4992} \
+    CONFIG.MC_LP4_RESETN_WIDTH {1} \
+    CONFIG.MC_MEMORY_SPEEDGRADE {LPDDR4-4267} \
+    CONFIG.MC_MEMORY_TIMEPERIOD0 {512} \
+    CONFIG.MC_NO_CHANNELS {Dual} \
+    CONFIG.MC_ODTLon {8} \
+    CONFIG.MC_PER_RD_INTVL {0} \
+    CONFIG.MC_PRE_DEF_ADDR_MAP_SEL {ROW_COLUMN_BANK} \
+    CONFIG.MC_SHARED_SEGMENTS {0} \
+    CONFIG.MC_TCCD_L {0} \
+    CONFIG.MC_TCKE {15} \
+    CONFIG.MC_TCKEMIN {15} \
+    CONFIG.MC_TFAW {30000} \
+    CONFIG.MC_TFAWMIN {30000} \
+    CONFIG.MC_TMOD {0} \
+    CONFIG.MC_TMRD {14000} \
+    CONFIG.MC_TMRDMIN {14000} \
+    CONFIG.MC_TMRD_div4 {10} \
+    CONFIG.MC_TMRW {10000} \
+    CONFIG.MC_TMRW_div4 {10} \
+    CONFIG.MC_TODTon_MIN {3} \
+    CONFIG.MC_TOSCO {40000} \
+    CONFIG.MC_TPBR2PBR {90000} \
+    CONFIG.MC_TRAS {42000} \
+    CONFIG.MC_TRC {63000} \
+    CONFIG.MC_TRCD {18000} \
+    CONFIG.MC_TREFI {3904000} \
+    CONFIG.MC_TREFIPB {488000} \
+    CONFIG.MC_TRFC {0} \
+    CONFIG.MC_TRFCAB {280000} \
+    CONFIG.MC_TRFCMIN {0} \
+    CONFIG.MC_TRFCPB {140000} \
+    CONFIG.MC_TRFCPBMIN {140000} \
+    CONFIG.MC_TRP {0} \
+    CONFIG.MC_TRPAB {21000} \
+    CONFIG.MC_TRPMIN {0} \
+    CONFIG.MC_TRPPB {18000} \
+    CONFIG.MC_TRPRE {1.8} \
+    CONFIG.MC_TRRD {7500} \
+    CONFIG.MC_TRRD_L {0} \
+    CONFIG.MC_TRRD_S {0} \
+    CONFIG.MC_TRRD_S_MIN {0} \
+    CONFIG.MC_TWPRE {1.8} \
+    CONFIG.MC_TWPST {0.4} \
+    CONFIG.MC_TWR {18000} \
+    CONFIG.MC_TWTR {10000} \
+    CONFIG.MC_TWTR_L {0} \
+    CONFIG.MC_TWTR_S {0} \
+    CONFIG.MC_TWTR_S_MIN {0} \
+    CONFIG.MC_TXP {15} \
+    CONFIG.MC_TXPMIN {15} \
+    CONFIG.MC_TXPR {0} \
+    CONFIG.MC_TZQCAL {1000000} \
+    CONFIG.MC_TZQCAL_div4 {489} \
+    CONFIG.MC_TZQCS_ITVL {0} \
+    CONFIG.MC_TZQLAT {30000} \
+    CONFIG.MC_TZQLATMIN {30000} \
+    CONFIG.MC_TZQLAT_div4 {15} \
+    CONFIG.MC_TZQLAT_nCK {59} \
+    CONFIG.MC_TZQ_START_ITVL {1000000000} \
+    CONFIG.MC_USER_DEFINED_ADDRESS_MAP {16RA-3BA-10CA} \
+    CONFIG.MC_XPLL_CLKOUT1_PERIOD {1024} \
+    CONFIG.NUM_CLKS {2} \
+    CONFIG.NUM_MC {1} \
+    CONFIG.NUM_MCP {4} \
+    CONFIG.NUM_MI {0} \
+    CONFIG.NUM_NSI {1} \
+    CONFIG.NUM_SI {3} \
+  ] $axi_noc_2
+
+
+  set_property -dict [ list \
+   CONFIG.CONNECTIONS {MC_1 {read_bw {500} write_bw {500} read_avg_burst {4} write_avg_burst {4} initial_boot {false}}} \
+   CONFIG.NOC_PARAMS {} \
+   CONFIG.CATEGORY {pl} \
+ ] [get_bd_intf_pins /axi_noc_2/S00_AXI]
+
+  set_property -dict [ list \
+   CONFIG.CONNECTIONS {MC_1 {read_bw {500} write_bw {500} read_avg_burst {4} write_avg_burst {4} initial_boot {true}}} \
+ ] [get_bd_intf_pins /axi_noc_2/S00_INI]
+
+  set_property -dict [ list \
+   CONFIG.CONNECTIONS {MC_1 {read_bw {500} write_bw {500} read_avg_burst {4} write_avg_burst {4} initial_boot {false}}} \
+   CONFIG.NOC_PARAMS {} \
+   CONFIG.CATEGORY {pl} \
+ ] [get_bd_intf_pins /axi_noc_2/S01_AXI]
+
+  set_property -dict [ list \
+   CONFIG.CONNECTIONS {MC_1 {read_bw {500} write_bw {500} read_avg_burst {4} write_avg_burst {4} initial_boot {true}}} \
+   CONFIG.NOC_PARAMS {} \
+   CONFIG.CATEGORY {ps_nci} \
+ ] [get_bd_intf_pins /axi_noc_2/S02_AXI]
+
+  set_property -dict [ list \
+   CONFIG.ASSOCIATED_BUSIF {S00_AXI:S01_AXI} \
+ ] [get_bd_pins /axi_noc_2/aclk0]
+
+  set_property -dict [ list \
+   CONFIG.ASSOCIATED_BUSIF {S02_AXI} \
+ ] [get_bd_pins /axi_noc_2/aclk1]
+
+  # Create instance: axi_cdma_0, and set properties
+  set axi_cdma_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_cdma axi_cdma_0 ]
+  set_property -dict [list \
+    CONFIG.C_ADDR_WIDTH {64} \
+    CONFIG.C_INCLUDE_SG {0} \
+    CONFIG.C_M_AXI_DATA_WIDTH {128} \
+    CONFIG.C_M_AXI_MAX_BURST_LEN {16} \
+  ] $axi_cdma_0
+
+
+  # Create instance: proc_sys_reset_0, and set properties
+  set proc_sys_reset_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:proc_sys_reset proc_sys_reset_0 ]
+
+  # Create instance: smartconnect_2, and set properties
+  set smartconnect_2 [ create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect smartconnect_2 ]
+  set_property -dict [list \
+    CONFIG.NUM_MI {3} \
+    CONFIG.NUM_SI {2} \
+  ] $smartconnect_2
+
+
+  # Create instance: emb_fifo_gen_0, and set properties
+  set emb_fifo_gen_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:emb_fifo_gen emb_fifo_gen_0 ]
+  set_property -dict [list \
+    CONFIG.AXI_ADDR_WIDTH {64} \
+    CONFIG.AXI_DATA_WIDTH {128} \
+    CONFIG.INTERFACE_TYPE {AXI4_Full} \
+  ] $emb_fifo_gen_0
+
+
+  # Create instance: smartconnect_3, and set properties
+  set smartconnect_3 [ create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect smartconnect_3 ]
+  set_property -dict [list \
+    CONFIG.NUM_MI {2} \
+    CONFIG.NUM_SI {1} \
+  ] $smartconnect_3
+
+
+  # Create instance: smartconnect_0, and set properties
+  set smartconnect_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect smartconnect_0 ]
+  set_property CONFIG.NUM_SI {1} $smartconnect_0
+
+
+  # Create instance: axis_ila_0, and set properties
+  set axis_ila_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axis_ila axis_ila_0 ]
+  set_property -dict [list \
+    CONFIG.C_MON_TYPE {Mixed} \
+    CONFIG.C_NUM_MONITOR_SLOTS {7} \
+    CONFIG.C_PROBE0_TYPE {0} \
+    CONFIG.C_PROBE0_WIDTH {1} \
+    CONFIG.C_SLOT_0_APC_EN {0} \
+    CONFIG.C_SLOT_0_AXI_AR_SEL_DATA {1} \
+    CONFIG.C_SLOT_0_AXI_AR_SEL_TRIG {1} \
+    CONFIG.C_SLOT_0_AXI_AW_SEL_DATA {1} \
+    CONFIG.C_SLOT_0_AXI_AW_SEL_TRIG {1} \
+    CONFIG.C_SLOT_0_AXI_B_SEL_DATA {1} \
+    CONFIG.C_SLOT_0_AXI_B_SEL_TRIG {1} \
+    CONFIG.C_SLOT_0_AXI_R_SEL_DATA {1} \
+    CONFIG.C_SLOT_0_AXI_R_SEL_TRIG {1} \
+    CONFIG.C_SLOT_0_AXI_W_SEL_DATA {1} \
+    CONFIG.C_SLOT_0_AXI_W_SEL_TRIG {1} \
+    CONFIG.C_SLOT_1_APC_EN {0} \
+    CONFIG.C_SLOT_1_AXI_AR_SEL_DATA {1} \
+    CONFIG.C_SLOT_1_AXI_AR_SEL_TRIG {1} \
+    CONFIG.C_SLOT_1_AXI_AW_SEL_DATA {1} \
+    CONFIG.C_SLOT_1_AXI_AW_SEL_TRIG {1} \
+    CONFIG.C_SLOT_1_AXI_B_SEL_DATA {1} \
+    CONFIG.C_SLOT_1_AXI_B_SEL_TRIG {1} \
+    CONFIG.C_SLOT_1_AXI_R_SEL_DATA {1} \
+    CONFIG.C_SLOT_1_AXI_R_SEL_TRIG {1} \
+    CONFIG.C_SLOT_1_AXI_W_SEL_DATA {1} \
+    CONFIG.C_SLOT_1_AXI_W_SEL_TRIG {1} \
+    CONFIG.C_SLOT_2_INTF_TYPE {xilinx.com:display_eqdma:s_axis_c2h_cmpt_rtl:1.0} \
+    CONFIG.C_SLOT_2_TYPE {0} \
+    CONFIG.C_SLOT_3_INTF_TYPE {xilinx.com:display_eqdma:s_axis_c2h_rtl:1.0} \
+    CONFIG.C_SLOT_3_TYPE {0} \
+    CONFIG.C_SLOT_4_INTF_TYPE {xilinx.com:display_eqdma:m_axis_h2c_rtl:1.0} \
+    CONFIG.C_SLOT_4_TYPE {0} \
+    CONFIG.C_SLOT_5_APC_EN {0} \
+    CONFIG.C_SLOT_5_AXI_AR_SEL_DATA {1} \
+    CONFIG.C_SLOT_5_AXI_AR_SEL_TRIG {1} \
+    CONFIG.C_SLOT_5_AXI_AW_SEL_DATA {1} \
+    CONFIG.C_SLOT_5_AXI_AW_SEL_TRIG {1} \
+    CONFIG.C_SLOT_5_AXI_B_SEL_DATA {1} \
+    CONFIG.C_SLOT_5_AXI_B_SEL_TRIG {1} \
+    CONFIG.C_SLOT_5_AXI_R_SEL_DATA {1} \
+    CONFIG.C_SLOT_5_AXI_R_SEL_TRIG {1} \
+    CONFIG.C_SLOT_5_AXI_W_SEL_DATA {1} \
+    CONFIG.C_SLOT_5_AXI_W_SEL_TRIG {1} \
+    CONFIG.C_SLOT_6_INTF_TYPE {xilinx.com:interface:qdma_usr_irq_rtl:1.0} \
+    CONFIG.C_SLOT_6_TYPE {0} \
+    CONFIG.C_SLOT_7_APC_EN {0} \
+    CONFIG.C_SLOT_7_AXI_AR_SEL_DATA {1} \
+    CONFIG.C_SLOT_7_AXI_AR_SEL_TRIG {1} \
+    CONFIG.C_SLOT_7_AXI_AW_SEL_DATA {1} \
+    CONFIG.C_SLOT_7_AXI_AW_SEL_TRIG {1} \
+    CONFIG.C_SLOT_7_AXI_B_SEL_DATA {1} \
+    CONFIG.C_SLOT_7_AXI_B_SEL_TRIG {1} \
+    CONFIG.C_SLOT_7_AXI_R_SEL_DATA {1} \
+    CONFIG.C_SLOT_7_AXI_R_SEL_TRIG {1} \
+    CONFIG.C_SLOT_7_AXI_W_SEL_DATA {1} \
+    CONFIG.C_SLOT_7_AXI_W_SEL_TRIG {1} \
+  ] $axis_ila_0
+
+
+  # Create interface connections
+  connect_bd_intf_net -intf_net M_AXIL [get_bd_intf_ports M_AXIL] [get_bd_intf_pins smartconnect_2/M02_AXI]
+  connect_bd_intf_net -intf_net axi_cdma_0_M_AXI [get_bd_intf_pins smartconnect_3/S00_AXI] [get_bd_intf_pins axi_cdma_0/M_AXI]
+connect_bd_intf_net -intf_net [get_bd_intf_nets axi_cdma_0_M_AXI] [get_bd_intf_pins smartconnect_3/S00_AXI] [get_bd_intf_pins axis_ila_0/SLOT_0_AXI]
+  set_property HDL_ATTRIBUTE.DEBUG {true} [get_bd_intf_nets axi_cdma_0_M_AXI]
+  connect_bd_intf_net -intf_net axi_cdma_axi_lite [get_bd_intf_pins smartconnect_2/M00_AXI] [get_bd_intf_pins axi_cdma_0/S_AXI_LITE]
+  connect_bd_intf_net -intf_net axi_noc_0_CH0_LPDDR4_0 [get_bd_intf_ports CH0_LPDDR4_0_0] [get_bd_intf_pins axi_noc_0/CH0_LPDDR4_0]
+  connect_bd_intf_net -intf_net axi_noc_0_CH1_LPDDR4_0 [get_bd_intf_ports CH1_LPDDR4_0_0] [get_bd_intf_pins axi_noc_0/CH1_LPDDR4_0]
+  connect_bd_intf_net -intf_net axi_noc_0_M00_INI [get_bd_intf_pins axi_noc_0/M00_INI] [get_bd_intf_pins axi_noc_2/S00_INI]
+  connect_bd_intf_net -intf_net axi_noc_1_CH0_LPDDR4_0 [get_bd_intf_ports CH0_LPDDR4_0_1] [get_bd_intf_pins axi_noc_1/CH0_LPDDR4_0]
+  connect_bd_intf_net -intf_net axi_noc_1_CH1_LPDDR4_0 [get_bd_intf_ports CH1_LPDDR4_0_1] [get_bd_intf_pins axi_noc_1/CH1_LPDDR4_0]
+  connect_bd_intf_net -intf_net axi_noc_1_M00_AXI [get_bd_intf_pins axi_noc_1/M00_AXI] [get_bd_intf_pins versal_cips_0/NOC_PMC_AXI_0]
+  connect_bd_intf_net -intf_net axi_noc_2_CH0_LPDDR4_0 [get_bd_intf_ports CH0_LPDDR4_0_2] [get_bd_intf_pins axi_noc_2/CH0_LPDDR4_0]
+  connect_bd_intf_net -intf_net axi_noc_2_CH1_LPDDR4_0 [get_bd_intf_ports CH1_LPDDR4_0_2] [get_bd_intf_pins axi_noc_2/CH1_LPDDR4_0]
+  connect_bd_intf_net -intf_net cdma_m_axi_to_DDR [get_bd_intf_pins smartconnect_3/M00_AXI] [get_bd_intf_pins axi_noc_2/S00_AXI]
+  connect_bd_intf_net -intf_net dma0_c2h_byp_in_mm_0_0_1 [get_bd_intf_ports dma0_c2h_byp_in_mm_0_0] [get_bd_intf_pins versal_cips_0/dma0_c2h_byp_in_mm_0]
+  connect_bd_intf_net -intf_net dma0_c2h_byp_in_mm_1_0_1 [get_bd_intf_ports dma0_c2h_byp_in_mm_1_0] [get_bd_intf_pins versal_cips_0/dma0_c2h_byp_in_mm_1]
+  connect_bd_intf_net -intf_net dma0_c2h_byp_in_st_csh_0_1 [get_bd_intf_ports dma0_c2h_byp_in_st_csh_0] [get_bd_intf_pins versal_cips_0/dma0_c2h_byp_in_st_csh]
+  connect_bd_intf_net -intf_net dma0_s_axis_c2h_cmpt_0_1 [get_bd_intf_ports dma0_s_axis_c2h_cmpt_0] [get_bd_intf_pins versal_cips_0/dma0_s_axis_c2h_cmpt]
+connect_bd_intf_net -intf_net [get_bd_intf_nets dma0_s_axis_c2h_cmpt_0_1] [get_bd_intf_ports dma0_s_axis_c2h_cmpt_0] [get_bd_intf_pins axis_ila_0/SLOT_2_S_AXIS_C2H_CMPT]
+  set_property HDL_ATTRIBUTE.DEBUG {true} [get_bd_intf_nets dma0_s_axis_c2h_cmpt_0_1]
+  connect_bd_intf_net -intf_net dma1_dsc_crdt_in_0_1 [get_bd_intf_ports dma0_dsc_crdt_in_0] [get_bd_intf_pins versal_cips_0/dma0_dsc_crdt_in]
+  connect_bd_intf_net -intf_net dma1_s_axis_c2h_0_1 [get_bd_intf_ports dma0_s_axis_c2h_0] [get_bd_intf_pins versal_cips_0/dma0_s_axis_c2h]
+connect_bd_intf_net -intf_net [get_bd_intf_nets dma1_s_axis_c2h_0_1] [get_bd_intf_ports dma0_s_axis_c2h_0] [get_bd_intf_pins axis_ila_0/SLOT_3_S_AXIS_C2H]
+  set_property HDL_ATTRIBUTE.DEBUG {true} [get_bd_intf_nets dma1_s_axis_c2h_0_1]
+  connect_bd_intf_net -intf_net emb_fifo_gen_0_M_AXI [get_bd_intf_pins emb_fifo_gen_0/M_AXI] [get_bd_intf_pins smartconnect_0/S00_AXI]
+  connect_bd_intf_net -intf_net fifo_s_axi [get_bd_intf_pins smartconnect_3/M01_AXI] [get_bd_intf_pins emb_fifo_gen_0/S_AXI]
+  connect_bd_intf_net -intf_net gt_refclk1_0_1 [get_bd_intf_ports gt_refclk0_0] [get_bd_intf_pins versal_cips_0/gt_refclk0]
+  connect_bd_intf_net -intf_net pcie_noc1_2_AXIL [get_bd_intf_pins axi_noc_1/M01_AXI] [get_bd_intf_pins smartconnect_2/S00_AXI]
+connect_bd_intf_net -intf_net [get_bd_intf_nets pcie_noc1_2_AXIL] [get_bd_intf_pins axi_noc_1/M01_AXI] [get_bd_intf_pins axis_ila_0/SLOT_1_AXI]
+  set_property HDL_ATTRIBUTE.DEBUG {true} [get_bd_intf_nets pcie_noc1_2_AXIL]
+  connect_bd_intf_net -intf_net ps_pl_axil [get_bd_intf_ports ps_pl_axil] [get_bd_intf_pins smartconnect_2/M01_AXI]
+  connect_bd_intf_net -intf_net smartconnect_0_M00_AXI [get_bd_intf_pins smartconnect_0/M00_AXI] [get_bd_intf_pins axi_noc_2/S01_AXI]
+  connect_bd_intf_net -intf_net sys_clk0_0_1 [get_bd_intf_ports sys_clk0_0] [get_bd_intf_pins axi_noc_0/sys_clk0]
+  connect_bd_intf_net -intf_net sys_clk0_1_1 [get_bd_intf_ports sys_clk0_1] [get_bd_intf_pins axi_noc_1/sys_clk0]
+  connect_bd_intf_net -intf_net sys_clk0_2_1 [get_bd_intf_ports sys_clk0_2] [get_bd_intf_pins axi_noc_2/sys_clk0]
+  connect_bd_intf_net -intf_net usr_irq_0_1 [get_bd_intf_ports usr_irq_0] [get_bd_intf_pins versal_cips_0/dma0_usr_irq]
+connect_bd_intf_net -intf_net [get_bd_intf_nets usr_irq_0_1] [get_bd_intf_ports usr_irq_0] [get_bd_intf_pins axis_ila_0/SLOT_6_QDMA_USR_IRQ]
+  set_property HDL_ATTRIBUTE.DEBUG {true} [get_bd_intf_nets usr_irq_0_1]
+  connect_bd_intf_net -intf_net versal_cips_0_CPM_PCIE_NOC_0 [get_bd_intf_pins axi_noc_0/S00_AXI] [get_bd_intf_pins versal_cips_0/CPM_PCIE_NOC_0]
+  connect_bd_intf_net -intf_net versal_cips_0_CPM_PCIE_NOC_1 [get_bd_intf_pins versal_cips_0/CPM_PCIE_NOC_1] [get_bd_intf_pins axi_noc_1/S00_AXI]
+  connect_bd_intf_net -intf_net versal_cips_0_FPD_AXI_NOC_0 [get_bd_intf_pins versal_cips_0/FPD_AXI_NOC_0] [get_bd_intf_pins axi_noc_2/S02_AXI]
+  connect_bd_intf_net -intf_net versal_cips_0_FPD_CCI_NOC_0 [get_bd_intf_pins versal_cips_0/FPD_CCI_NOC_0] [get_bd_intf_pins axi_noc_0/S01_AXI]
+  connect_bd_intf_net -intf_net versal_cips_0_FPD_CCI_NOC_1 [get_bd_intf_pins versal_cips_0/FPD_CCI_NOC_1] [get_bd_intf_pins axi_noc_0/S02_AXI]
+  connect_bd_intf_net -intf_net versal_cips_0_FPD_CCI_NOC_2 [get_bd_intf_pins versal_cips_0/FPD_CCI_NOC_2] [get_bd_intf_pins axi_noc_0/S03_AXI]
+  connect_bd_intf_net -intf_net versal_cips_0_FPD_CCI_NOC_3 [get_bd_intf_pins versal_cips_0/FPD_CCI_NOC_3] [get_bd_intf_pins axi_noc_0/S04_AXI]
+  connect_bd_intf_net -intf_net versal_cips_0_M_AXI_FPD [get_bd_intf_pins versal_cips_0/M_AXI_FPD] [get_bd_intf_pins smartconnect_2/S01_AXI]
+connect_bd_intf_net -intf_net [get_bd_intf_nets versal_cips_0_M_AXI_FPD] [get_bd_intf_pins versal_cips_0/M_AXI_FPD] [get_bd_intf_pins axis_ila_0/SLOT_5_AXI]
+  set_property HDL_ATTRIBUTE.DEBUG {true} [get_bd_intf_nets versal_cips_0_M_AXI_FPD]
+  connect_bd_intf_net -intf_net versal_cips_0_PCIE0_GT [get_bd_intf_ports PCIE0_GT_0] [get_bd_intf_pins versal_cips_0/PCIE0_GT]
+  connect_bd_intf_net -intf_net versal_cips_0_PMC_NOC_AXI_0 [get_bd_intf_pins versal_cips_0/PMC_NOC_AXI_0] [get_bd_intf_pins axi_noc_0/S05_AXI]
+  connect_bd_intf_net -intf_net versal_cips_0_dma0_axis_c2h_dmawr [get_bd_intf_ports dma0_axis_c2h_dmawr_0] [get_bd_intf_pins versal_cips_0/dma0_axis_c2h_dmawr]
+  connect_bd_intf_net -intf_net versal_cips_0_dma0_axis_c2h_status [get_bd_intf_ports dma0_axis_c2h_status_0] [get_bd_intf_pins versal_cips_0/dma0_axis_c2h_status]
+  connect_bd_intf_net -intf_net versal_cips_0_dma0_c2h_byp_out [get_bd_intf_ports dma0_c2h_byp_out_0] [get_bd_intf_pins versal_cips_0/dma0_c2h_byp_out]
+  connect_bd_intf_net -intf_net versal_cips_0_dma0_m_axis_h2c [get_bd_intf_ports dma0_m_axis_h2c_0] [get_bd_intf_pins versal_cips_0/dma0_m_axis_h2c]
+connect_bd_intf_net -intf_net [get_bd_intf_nets versal_cips_0_dma0_m_axis_h2c] [get_bd_intf_ports dma0_m_axis_h2c_0] [get_bd_intf_pins axis_ila_0/SLOT_4_M_AXIS_H2C]
+  set_property HDL_ATTRIBUTE.DEBUG {true} [get_bd_intf_nets versal_cips_0_dma0_m_axis_h2c]
+  connect_bd_intf_net -intf_net versal_cips_0_dma0_qsts_out [get_bd_intf_ports dma0_qsts_out_0] [get_bd_intf_pins versal_cips_0/dma0_qsts_out]
+  connect_bd_intf_net -intf_net versal_cips_0_dma0_st_rx_msg [get_bd_intf_ports dma0_st_rx_msg_0] [get_bd_intf_pins versal_cips_0/dma0_st_rx_msg]
+  connect_bd_intf_net -intf_net versal_cips_0_dma0_tm_dsc_sts [get_bd_intf_ports dma0_tm_dsc_sts_0] [get_bd_intf_pins versal_cips_0/dma0_tm_dsc_sts]
+
+  # Create port connections
+  connect_bd_net -net axi_cdma_0_cdma_introut1  [get_bd_pins axi_cdma_0/cdma_introut] \
+  [get_bd_ports cdma_introut_0] \
+  [get_bd_pins versal_cips_0/pl_ps_irq9] \
+  [get_bd_pins axis_ila_0/probe0]
+  set_property HDL_ATTRIBUTE.DEBUG {true} [get_bd_nets axi_cdma_0_cdma_introut1]
+  connect_bd_net -net cpm_irq0_0_1  [get_bd_ports cpm_irq0_0] \
+  [get_bd_pins versal_cips_0/cpm_irq0]
+  connect_bd_net -net cpm_irq1_0_1  [get_bd_ports cpm_irq1_0] \
+  [get_bd_pins versal_cips_0/cpm_irq1]
+  connect_bd_net -net dma1_intrfc_resetn_0_1  [get_bd_ports dma0_intrfc_resetn_0] \
+  [get_bd_pins versal_cips_0/dma0_intrfc_resetn]
+  connect_bd_net -net proc_sys_reset_0_peripheral_aresetn  [get_bd_pins proc_sys_reset_0/peripheral_aresetn] \
+  [get_bd_pins axi_cdma_0/s_axi_lite_aresetn] \
+  [get_bd_pins smartconnect_2/aresetn] \
+  [get_bd_pins smartconnect_3/aresetn] \
+  [get_bd_pins emb_fifo_gen_0/s_aresetn] \
+  [get_bd_pins smartconnect_0/aresetn] \
+  [get_bd_pins axis_ila_0/resetn]
+  connect_bd_net -net versal_cips_0_cpm_cor_irq  [get_bd_pins versal_cips_0/cpm_cor_irq] \
+  [get_bd_ports cpm_cor_irq_0]
+  connect_bd_net -net versal_cips_0_cpm_misc_irq  [get_bd_pins versal_cips_0/cpm_misc_irq] \
+  [get_bd_ports cpm_misc_irq_0]
+  connect_bd_net -net versal_cips_0_cpm_pcie_noc_axi0_clk  [get_bd_pins versal_cips_0/cpm_pcie_noc_axi0_clk] \
+  [get_bd_pins axi_noc_0/aclk0]
+  connect_bd_net -net versal_cips_0_cpm_pcie_noc_axi1_clk  [get_bd_pins versal_cips_0/cpm_pcie_noc_axi1_clk] \
+  [get_bd_pins axi_noc_1/aclk1]
+  connect_bd_net -net versal_cips_0_cpm_uncor_irq  [get_bd_pins versal_cips_0/cpm_uncor_irq] \
+  [get_bd_ports cpm_uncor_irq_0]
+  connect_bd_net -net versal_cips_0_dma0_axi_aresetn  [get_bd_pins versal_cips_0/dma0_axi_aresetn] \
+  [get_bd_ports dma0_axi_aresetn_0]
+  connect_bd_net -net versal_cips_0_fpd_axi_noc_axi0_clk  [get_bd_pins versal_cips_0/fpd_axi_noc_axi0_clk] \
+  [get_bd_pins axi_noc_2/aclk1]
+  connect_bd_net -net versal_cips_0_fpd_cci_noc_axi0_clk  [get_bd_pins versal_cips_0/fpd_cci_noc_axi0_clk] \
+  [get_bd_pins axi_noc_0/aclk2]
+  connect_bd_net -net versal_cips_0_fpd_cci_noc_axi1_clk  [get_bd_pins versal_cips_0/fpd_cci_noc_axi1_clk] \
+  [get_bd_pins axi_noc_0/aclk3]
+  connect_bd_net -net versal_cips_0_fpd_cci_noc_axi2_clk  [get_bd_pins versal_cips_0/fpd_cci_noc_axi2_clk] \
+  [get_bd_pins axi_noc_0/aclk4]
+  connect_bd_net -net versal_cips_0_fpd_cci_noc_axi3_clk  [get_bd_pins versal_cips_0/fpd_cci_noc_axi3_clk] \
+  [get_bd_pins axi_noc_0/aclk5]
+  connect_bd_net -net versal_cips_0_noc_pmc_axi_axi0_clk  [get_bd_pins versal_cips_0/noc_pmc_axi_axi0_clk] \
+  [get_bd_pins axi_noc_1/aclk0]
+  connect_bd_net -net versal_cips_0_pl0_ref_clk  [get_bd_pins versal_cips_0/pl0_ref_clk] \
+  [get_bd_ports pcie0_user_clk_0] \
+  [get_bd_pins versal_cips_0/dma0_intrfc_clk] \
+  [get_bd_pins axi_noc_0/aclk1] \
+  [get_bd_pins axi_noc_2/aclk0] \
+  [get_bd_pins axi_cdma_0/m_axi_aclk] \
+  [get_bd_pins proc_sys_reset_0/slowest_sync_clk] \
+  [get_bd_pins axi_cdma_0/s_axi_lite_aclk] \
+  [get_bd_pins smartconnect_2/aclk] \
+  [get_bd_pins smartconnect_3/aclk] \
+  [get_bd_pins emb_fifo_gen_0/s_aclk] \
+  [get_bd_pins axi_noc_1/aclk2] \
+  [get_bd_pins versal_cips_0/m_axi_fpd_aclk] \
+  [get_bd_pins smartconnect_0/aclk] \
+  [get_bd_pins axis_ila_0/clk]
+  connect_bd_net -net versal_cips_0_pl0_resetn  [get_bd_pins versal_cips_0/pl0_resetn] \
+  [get_bd_pins proc_sys_reset_0/ext_reset_in]
+  connect_bd_net -net versal_cips_0_pmc_axi_noc_axi0_clk  [get_bd_pins versal_cips_0/pmc_axi_noc_axi0_clk] \
+  [get_bd_pins axi_noc_0/aclk6]
+
+  # Create address segments
+  assign_bd_address -offset 0x050000000000 -range 0x80000000 -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_0] [get_bd_addr_segs axi_noc_0/S00_AXI/C3_DDR_CH1] -force
+  assign_bd_address -offset 0x058000000000 -range 0x80000000 -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_0] [get_bd_addr_segs axi_noc_0/S00_AXI/C3_DDR_CH1_1] -force
+  assign_bd_address -offset 0x070000000000 -range 0x40000000 -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_0] [get_bd_addr_segs axi_noc_2/S00_INI/C1_DDR_CH3] -force
+  assign_bd_address -offset 0x078000000000 -range 0x40000000 -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_0] [get_bd_addr_segs axi_noc_2/S00_INI/C1_DDR_CH3_1] -force
+  assign_bd_address -offset 0x020100010000 -range 0x00010000 -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs M_AXIL/Reg] -force
+  assign_bd_address -offset 0x060000000000 -range 0x80000000 -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs axi_noc_1/S00_AXI/C2_DDR_CH2] -force
+  assign_bd_address -offset 0x068000000000 -range 0x80000000 -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs axi_noc_1/S00_AXI/C2_DDR_CH2_1] -force
+  assign_bd_address -offset 0x020104000000 -range 0x01000000 -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_cpm] -force
+  assign_bd_address -offset 0x020100330000 -range 0x00010000 -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_ipi_0] -force
+  assign_bd_address -offset 0x020100340000 -range 0x00010000 -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_ipi_1] -force
+  assign_bd_address -offset 0x020100320000 -range 0x00010000 -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_ipi_pmc] -force
+  assign_bd_address -offset 0x020100390000 -range 0x00010000 -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_ipi_pmc_nobuf] -force
+  assign_bd_address -offset 0x020100310000 -range 0x00010000 -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_ipi_psm] -force
+  assign_bd_address -offset 0x0201000C0000 -range 0x00040000 -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_ocm_ram_0] -force
+  assign_bd_address -offset 0x020101030000 -range 0x00010000 -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_qspi_0] -force
+  assign_bd_address -offset 0x020102000000 -range 0x00020000 -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_ram] -force
+  assign_bd_address -offset 0x020101220000 -range 0x00010000 -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_slave_boot] -force
+  assign_bd_address -offset 0x020102100000 -range 0x00010000 -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_slave_boot_stream] -force
+  assign_bd_address -offset 0x070000000000 -range 0x40000000 -target_address_space [get_bd_addr_spaces versal_cips_0/FPD_AXI_NOC_0] [get_bd_addr_segs axi_noc_2/S02_AXI/C1_DDR_CH3] -force
+  assign_bd_address -offset 0x078000000000 -range 0x40000000 -target_address_space [get_bd_addr_spaces versal_cips_0/FPD_AXI_NOC_0] [get_bd_addr_segs axi_noc_2/S02_AXI/C1_DDR_CH3_1] -force
+  assign_bd_address -offset 0x050000000000 -range 0x80000000 -target_address_space [get_bd_addr_spaces versal_cips_0/FPD_CCI_NOC_0] [get_bd_addr_segs axi_noc_0/S01_AXI/C3_DDR_CH1] -force
+  assign_bd_address -offset 0x058000000000 -range 0x80000000 -target_address_space [get_bd_addr_spaces versal_cips_0/FPD_CCI_NOC_0] [get_bd_addr_segs axi_noc_0/S01_AXI/C3_DDR_CH1_1] -force
+  assign_bd_address -offset 0x070000000000 -range 0x40000000 -target_address_space [get_bd_addr_spaces versal_cips_0/FPD_CCI_NOC_0] [get_bd_addr_segs axi_noc_2/S00_INI/C1_DDR_CH3] -force
+  assign_bd_address -offset 0x078000000000 -range 0x40000000 -target_address_space [get_bd_addr_spaces versal_cips_0/FPD_CCI_NOC_0] [get_bd_addr_segs axi_noc_2/S00_INI/C1_DDR_CH3_1] -force
+  assign_bd_address -offset 0x050000000000 -range 0x80000000 -target_address_space [get_bd_addr_spaces versal_cips_0/FPD_CCI_NOC_1] [get_bd_addr_segs axi_noc_0/S02_AXI/C3_DDR_CH1] -force
+  assign_bd_address -offset 0x058000000000 -range 0x80000000 -target_address_space [get_bd_addr_spaces versal_cips_0/FPD_CCI_NOC_1] [get_bd_addr_segs axi_noc_0/S02_AXI/C3_DDR_CH1_1] -force
+  assign_bd_address -offset 0x070000000000 -range 0x40000000 -target_address_space [get_bd_addr_spaces versal_cips_0/FPD_CCI_NOC_1] [get_bd_addr_segs axi_noc_2/S00_INI/C1_DDR_CH3] -force
+  assign_bd_address -offset 0x078000000000 -range 0x40000000 -target_address_space [get_bd_addr_spaces versal_cips_0/FPD_CCI_NOC_1] [get_bd_addr_segs axi_noc_2/S00_INI/C1_DDR_CH3_1] -force
+  assign_bd_address -offset 0x050000000000 -range 0x80000000 -target_address_space [get_bd_addr_spaces versal_cips_0/FPD_CCI_NOC_2] [get_bd_addr_segs axi_noc_0/S03_AXI/C3_DDR_CH1] -force
+  assign_bd_address -offset 0x058000000000 -range 0x80000000 -target_address_space [get_bd_addr_spaces versal_cips_0/FPD_CCI_NOC_2] [get_bd_addr_segs axi_noc_0/S03_AXI/C3_DDR_CH1_1] -force
+  assign_bd_address -offset 0x070000000000 -range 0x40000000 -target_address_space [get_bd_addr_spaces versal_cips_0/FPD_CCI_NOC_2] [get_bd_addr_segs axi_noc_2/S00_INI/C1_DDR_CH3] -force
+  assign_bd_address -offset 0x078000000000 -range 0x40000000 -target_address_space [get_bd_addr_spaces versal_cips_0/FPD_CCI_NOC_2] [get_bd_addr_segs axi_noc_2/S00_INI/C1_DDR_CH3_1] -force
+  assign_bd_address -offset 0x050000000000 -range 0x80000000 -target_address_space [get_bd_addr_spaces versal_cips_0/FPD_CCI_NOC_3] [get_bd_addr_segs axi_noc_0/S04_AXI/C3_DDR_CH1] -force
+  assign_bd_address -offset 0x058000000000 -range 0x80000000 -target_address_space [get_bd_addr_spaces versal_cips_0/FPD_CCI_NOC_3] [get_bd_addr_segs axi_noc_0/S04_AXI/C3_DDR_CH1_1] -force
+  assign_bd_address -offset 0x070000000000 -range 0x40000000 -target_address_space [get_bd_addr_spaces versal_cips_0/FPD_CCI_NOC_3] [get_bd_addr_segs axi_noc_2/S00_INI/C1_DDR_CH3] -force
+  assign_bd_address -offset 0x078000000000 -range 0x40000000 -target_address_space [get_bd_addr_spaces versal_cips_0/FPD_CCI_NOC_3] [get_bd_addr_segs axi_noc_2/S00_INI/C1_DDR_CH3_1] -force
+  assign_bd_address -offset 0xA4000000 -range 0x00010000 -target_address_space [get_bd_addr_spaces versal_cips_0/M_AXI_FPD] [get_bd_addr_segs axi_cdma_0/S_AXI_LITE/Reg] -force
+  assign_bd_address -offset 0xA4020000 -range 0x00010000 -target_address_space [get_bd_addr_spaces versal_cips_0/M_AXI_FPD] [get_bd_addr_segs ps_pl_axil/Reg] -force
+  assign_bd_address -offset 0x050000000000 -range 0x80000000 -target_address_space [get_bd_addr_spaces versal_cips_0/PMC_NOC_AXI_0] [get_bd_addr_segs axi_noc_0/S05_AXI/C3_DDR_CH1] -force
+  assign_bd_address -offset 0x058000000000 -range 0x80000000 -target_address_space [get_bd_addr_spaces versal_cips_0/PMC_NOC_AXI_0] [get_bd_addr_segs axi_noc_0/S05_AXI/C3_DDR_CH1_1] -force
+  assign_bd_address -offset 0x070000000000 -range 0x40000000 -target_address_space [get_bd_addr_spaces versal_cips_0/PMC_NOC_AXI_0] [get_bd_addr_segs axi_noc_2/S00_INI/C1_DDR_CH3] -force
+  assign_bd_address -offset 0x078000000000 -range 0x40000000 -target_address_space [get_bd_addr_spaces versal_cips_0/PMC_NOC_AXI_0] [get_bd_addr_segs axi_noc_2/S00_INI/C1_DDR_CH3_1] -force
+  assign_bd_address -offset 0x072000000000 -range 0x20000000 -target_address_space [get_bd_addr_spaces axi_cdma_0/Data] [get_bd_addr_segs axi_noc_2/S00_AXI/C1_DDR_CH3] -force
+  assign_bd_address -offset 0x078000000000 -range 0x40000000 -target_address_space [get_bd_addr_spaces axi_cdma_0/Data] [get_bd_addr_segs axi_noc_2/S00_AXI/C1_DDR_CH3_1] -force
+  assign_bd_address -offset 0x070000000000 -range 0x20000000 -with_name SEG_axi_noc_2_C1_DDR_CH3_2 -target_address_space [get_bd_addr_spaces axi_cdma_0/Data] [get_bd_addr_segs axi_noc_2/S01_AXI/C1_DDR_CH3] -force
+
+  # Exclude Address Segments
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces axi_cdma_0/Data] [get_bd_addr_segs axi_noc_2/S01_AXI/C1_DDR_CH3_1]
+  exclude_bd_addr_seg -offset 0x020100000000 -range 0x00010000 -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs axi_cdma_0/S_AXI_LITE/Reg]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs ps_pl_axil/Reg]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_adma_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_adma_1]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_adma_2]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_adma_3]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_adma_4]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_adma_5]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_adma_6]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_adma_7]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_apu_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_a720_cti]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_a720_dbg]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_a720_etm]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_a720_pmu]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_a721_cti]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_a721_dbg]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_a721_etm]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_a721_pmu]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_apu_cti]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_apu_ela]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_apu_etf]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_apu_fun]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_cpm_atm]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_cpm_cti2a]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_cpm_cti2d]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_cpm_ela2a]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_cpm_ela2b]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_cpm_ela2c]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_cpm_ela2d]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_cpm_fun]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_cpm_rom]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_fpd_atm]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_fpd_stm]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_coresight_lpd_atm]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_crf_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_crl_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_crp_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_fpd_afi_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_fpd_afi_2]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_fpd_cci_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_fpd_gpv_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_fpd_maincci_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_fpd_slave_xmpu_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_fpd_slcr_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_fpd_slcr_secure_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_fpd_smmu_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_fpd_smmutcu_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_lpd_afi_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_lpd_iou_secure_slcr_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_lpd_iou_slcr_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_lpd_slcr_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_lpd_slcr_secure_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_lpd_xppu_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_ocm_ctrl]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_ocm_xmpu_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_aes]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_bbram_ctrl]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_cfi_cframe_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_cfu_apb_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_dma_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_dma_1]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_efuse_cache]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_efuse_ctrl]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_global_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_iomodule_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_ppu1_mdm_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_qspi_ospi_flash_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_ram_data_cntlr]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_ram_instr_cntlr]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_ram_npi]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_rsa]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_rtc_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_sha]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_sysmon_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_tmr_inject_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_tmr_manager_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_trng]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_xmpu_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_xppu_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_pmc_xppu_npi_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_psm_global_reg]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_r5_1_atcm_global]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_r5_1_btcm_global]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_r5_tcm_ram_global]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_rpu_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_sbsauart_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_scntr_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/CPM_PCIE_NOC_1] [get_bd_addr_segs versal_cips_0/NOC_PMC_AXI_0/pspmc_0_psv_scntrs_0]
+  exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces versal_cips_0/M_AXI_FPD] [get_bd_addr_segs M_AXIL/Reg]
+
+
+  # Restore current instance
+  current_bd_instance $oldCurInst
+
+  validate_bd_design
+  save_bd_design
+}
+# End of create_root_design()
+
+
+##################################################################
+# MAIN FLOW
+##################################################################
+
+create_root_design ""
+
+

--- a/ced/Xilinx/IPI/Versal_CPM_QDMA_Accel_Sys_Design/scripts/design_1_bd.tcl
+++ b/ced/Xilinx/IPI/Versal_CPM_QDMA_Accel_Sys_Design/scripts/design_1_bd.tcl
@@ -18,21 +18,6 @@ variable script_folder
 set script_folder [_tcl::get_script_folder]
 
 ################################################################
-# Check if script is running in correct Vivado version.
-#
-# NOTE - set scripts_vivado_version "" to ignore version check.
-################################################################
-set scripts_vivado_version ""
-#set scripts_vivado_version 2024.2
-set current_vivado_version [version -short]
-
-if { $scripts_vivado_version ne "" && [string first $scripts_vivado_version $current_vivado_version] == -1 } {
-   puts ""
-   common::send_gid_msg -ssname BD::TCL -id 2040 -severity "CRITICAL WARNING" "This script was generated using Vivado <$scripts_vivado_version> without IP versions in the create_bd_cell commands, but is now being run in <$current_vivado_version> of Vivado. There may have been changes to the IP between Vivado <$scripts_vivado_version> and <$current_vivado_version>, which could impact the functionality and configuration of the design."
-
-}
-
-################################################################
 # START
 ################################################################
 

--- a/ced/Xilinx/IPI/Versal_CPM_QDMA_Accel_Sys_Design/scripts/host_profile_noc0_1.sh
+++ b/ced/Xilinx/IPI/Versal_CPM_QDMA_Accel_Sys_Design/scripts/host_profile_noc0_1.sh
@@ -1,0 +1,36 @@
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x2c8 0x0
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x308 0x0
+
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x824 0xffffffff 
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x828 0xffffffff 
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x82C 0xffffffff 
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x830 0xffffffff 
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x834 0xffffffff 
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x838 0xffffffff 
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x83C 0xffffffff 
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x840 0xffffffff 
+
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x804 0x0 
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x808 0x0
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x80C 0x00000000
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x810 0x0
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x814 0x0
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x818 0x00000000
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x81C 0x0
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x820 0x0
+
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x844 0x34
+
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x2c8 0x0
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x308 0x0
+
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x804 0x0 
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x808 0x0
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x80C 0x40000000
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x810 0x0
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x814 0x0
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x818 0x00040000
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x81C 0x0
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x820 0x0
+
+/usr/local/sbin/dma-ctl qdma01000 reg write bar 0 0x844 0xb4

--- a/ced/Xilinx/IPI/Versal_CPM_QDMA_Accel_Sys_Design/src/qdma_accel_sys.bif
+++ b/ced/Xilinx/IPI/Versal_CPM_QDMA_Accel_Sys_Design/src/qdma_accel_sys.bif
@@ -2,7 +2,7 @@ all: {
 image {
 partition {
 type = bootimage
-file = ./design_1_wrapper_pld.pdi
+file = ./design_1_wrapper_boot.pdi
 }
 }
 image {


### PR DESCRIPTION
1. Provide a different BD.tcl to support MP device with VPK120 board
2. Provide additional details about the design, testing and fix issues with example commands
3. New host side script file to program host profile registers of QDMA
4. bif file update to use boot.pdi to integrate with .elf file
5. Changelog contents for initial version of the design. 