### PR TITLE
CR-1251869 - Updated CED Design's

### DIFF
--- a/ced/Xilinx/IPI/MicroBlaze_Design_Presets/init.tcl
+++ b/ced/Xilinx/IPI/MicroBlaze_Design_Presets/init.tcl
@@ -30,7 +30,8 @@ proc getSupportedParts {} {
 proc getSupportedBoards {} {
   #return [get_board_parts -filter {(BOARD_NAME =~"*vck190*" && VENDOR_NAME=="xilinx.com" ) || (BOARD_NAME =~"*vmk180*" && VENDOR_NAME=="xilinx.com" )}  -latest_file_version]
   # return [get_board_parts -filter {(PART_NAME!~"*xc7z*" && PART_NAME!~"*xcvc*" && PART_NAME!~"*xcvm*" && PART_NAME!~"*xcvp*" &&  PART_NAME!~"*xczu*" && VENDOR_NAME=="xilinx.com")} -latest_file_version]
-  return [get_board_parts -filter {(DISPLAY_NAME =~"*Kintex*" || DISPLAY_NAME =~"*Artix*" || DISPLAY_NAME =~"*Virtex*" || DISPLAY_NAME =~"*Spartan*" && VENDOR_NAME=="xilinx.com" )} -latest_file_version]
+#  return [get_board_parts -filter {(DISPLAY_NAME =~"*Kintex*" || DISPLAY_NAME =~"*Artix*" || DISPLAY_NAME =~"*Virtex*" || DISPLAY_NAME =~"*Spartan*" && VENDOR_NAME=="xilinx.com" )} -latest_file_version]
+  return [get_board_parts -filter {(DISPLAY_NAME =~"*Kintex*" || DISPLAY_NAME =~"*Artix*" || DISPLAY_NAME =~"*Virtex*" || DISPLAY_NAME =~ "*Spartan*" && VENDOR_NAME=="xilinx.com" && (NAME != "xilinx.com:scu200_es:part0:1.0"))} -latest_file_version]
 }
 
 # proc addOptions {DESIGNOBJ PROJECT_PARAM.BOARD_PART} {

--- a/ced/Xilinx/IPI/MicroBlaze_Design_Presets/mb_preset.tcl
+++ b/ced/Xilinx/IPI/MicroBlaze_Design_Presets/mb_preset.tcl
@@ -138,7 +138,10 @@ proc createDesign {design_name options} {
                 delete_bd_objs [get_bd_nets reset_0_1] [get_bd_ports reset_0]
                 connect_bd_net [get_bd_ports reset] [get_bd_pins rst_clk_wiz_1_100M/ext_reset_in]
 
-                puts "#***********************************Debug: Default Board interfaces Added**************************************#"
+                create_bd_cell -type ip -vlnv xilinx.com:ip:pmcbridge:* pmcbridge_0
+                apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {/clk_wiz_1/clk_out1 (100 MHz)} Clk_slave {Auto} Clk_xbar {/clk_wiz_1/clk_out1 (100 MHz)} Master {/microblaze_0 (Periph)} Slave {/pmcbridge_0/S_AXI} ddr_seg {Auto} intc_ip {/microblaze_0_axi_periph} master_apm {0}}  [get_bd_intf_pins pmcbridge_0/S_AXI]
+
+#                 puts "#***********************************Debug: Default Board interfaces Added**************************************#"
 
             } else { 
 

--- a/ced/Xilinx/IPI/mb_preset_xcsu/run.tcl
+++ b/ced/Xilinx/IPI/mb_preset_xcsu/run.tcl
@@ -62,6 +62,9 @@ if {([lsearch $temp_options Preset.VALUE] == -1) || ([lsearch $temp_options "Mic
 	apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {/clk_wiz_1/clk_out1 (100 MHz)} Clk_slave {Auto} Clk_xbar {/clk_wiz_1/clk_out1 (100 MHz)} Master {/microblaze_0 (Periph)} Slave {/axi_uartlite_0/S_AXI} ddr_seg {Auto} intc_ip {/microblaze_0_axi_periph} master_apm {0}}  [get_bd_intf_pins axi_uartlite_0/S_AXI]
 	apply_bd_automation -rule xilinx.com:bd_rule:board -config { Manual_Source {Auto}}  [get_bd_intf_pins axi_uartlite_0/UART]
 
+    create_bd_cell -type ip -vlnv xilinx.com:ip:pmcbridge:* pmcbridge_0
+    apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {/clk_wiz_1/clk_out1 (100 MHz)} Clk_slave {Auto} Clk_xbar {/clk_wiz_1/clk_out1 (100 MHz)} Master {/microblaze_0 (Periph)} Slave {/pmcbridge_0/S_AXI} ddr_seg {Auto} intc_ip {/microblaze_0_axi_periph} master_apm {0}}  [get_bd_intf_pins pmcbridge_0/S_AXI]
+
 	assign_bd_address
 
 } elseif { ([lsearch $temp_options "Real-time_Processor"] != -1 )} {
@@ -83,7 +86,10 @@ if {([lsearch $temp_options Preset.VALUE] == -1) || ([lsearch $temp_options "Mic
 	
 	apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {/clk_wiz_1/clk_out1 (100 MHz)} Clk_slave {Auto} Clk_xbar {/clk_wiz_1/clk_out1 (100 MHz)} Master {/microblaze_0 (Periph)} Slave {/axi_uartlite_0/S_AXI} ddr_seg {Auto} intc_ip {/microblaze_0_axi_periph} master_apm {0}}  [get_bd_intf_pins axi_uartlite_0/S_AXI]
 	apply_bd_automation -rule xilinx.com:bd_rule:board -config { Manual_Source {Auto}}  [get_bd_intf_pins axi_uartlite_0/UART]
-	
+
+    create_bd_cell -type ip -vlnv xilinx.com:ip:pmcbridge:* pmcbridge_0
+    apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {/clk_wiz_1/clk_out1 (100 MHz)} Clk_slave {Auto} Clk_xbar {/clk_wiz_1/clk_out1 (100 MHz)} Master {/microblaze_0 (Periph)} Slave {/pmcbridge_0/S_AXI} ddr_seg {Auto} intc_ip {/microblaze_0_axi_periph} master_apm {0}}  [get_bd_intf_pins pmcbridge_0/S_AXI]
+
 	assign_bd_address
 	set_property range 32K [get_bd_addr_segs {microblaze_0/Data/SEG_axi_bram_ctrl_0_Mem0}]
 	set_property range 32K [get_bd_addr_segs {microblaze_0/Instruction/SEG_axi_bram_ctrl_0_Mem0}]
@@ -123,7 +129,10 @@ if {([lsearch $temp_options Preset.VALUE] == -1) || ([lsearch $temp_options "Mic
 	
 	apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {/clk_wiz_1/clk_out1 (100 MHz)} Clk_slave {Auto} Clk_xbar {/clk_wiz_1/clk_out1 (100 MHz)} Master {/microblaze_0 (Periph)} Slave {/axi_uartlite_0/S_AXI} ddr_seg {Auto} intc_ip {/microblaze_0_axi_periph} master_apm {0}}  [get_bd_intf_pins axi_uartlite_0/S_AXI]
 	apply_bd_automation -rule xilinx.com:bd_rule:board -config { Manual_Source {Auto}}  [get_bd_intf_pins axi_uartlite_0/UART]
-	
+
+    create_bd_cell -type ip -vlnv xilinx.com:ip:pmcbridge:* pmcbridge_0
+    apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {/clk_wiz_1/clk_out1 (100 MHz)} Clk_slave {Auto} Clk_xbar {/clk_wiz_1/clk_out1 (100 MHz)} Master {/microblaze_0 (Periph)} Slave {/pmcbridge_0/S_AXI} ddr_seg {Auto} intc_ip {/microblaze_0_axi_periph} master_apm {0}}  [get_bd_intf_pins pmcbridge_0/S_AXI]
+
 	assign_bd_address
 	set_property range 32K [get_bd_addr_segs {microblaze_0/Instruction/SEG_axi_bram_ctrl_0_Mem0}]
 	set_property range 32K [get_bd_addr_segs {microblaze_0/Data/SEG_axi_bram_ctrl_0_Mem0}]

--- a/ced/Xilinx/IPI/mb_v_preset_xcsu/run.tcl
+++ b/ced/Xilinx/IPI/mb_v_preset_xcsu/run.tcl
@@ -60,6 +60,9 @@ if {([lsearch $temp_options Preset.VALUE] == -1) || ([lsearch $temp_options "Mic
 	apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {/clk_wiz_1/clk_out1 (100 MHz)} Clk_slave {Auto} Clk_xbar {/clk_wiz_1/clk_out1 (100 MHz)} Master {/microblaze_riscv_0 (Periph)} Slave {/axi_uartlite_0/S_AXI} ddr_seg {Auto} intc_ip {/microblaze_riscv_0_axi_periph} master_apm {0}}  [get_bd_intf_pins axi_uartlite_0/S_AXI]
 	apply_bd_automation -rule xilinx.com:bd_rule:board -config { Manual_Source {Auto}}  [get_bd_intf_pins axi_uartlite_0/UART]
 
+    create_bd_cell -type ip -vlnv xilinx.com:ip:pmcbridge:* pmcbridge_0
+    apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {/clk_wiz_1/clk_out1 (100 MHz)} Clk_slave {Auto} Clk_xbar {/clk_wiz_1/clk_out1 (100 MHz)} Master {/microblaze_riscv_0 (Periph)} Slave {/pmcbridge_0/S_AXI} ddr_seg {Auto} intc_ip {/microblaze_riscv_0_axi_periph} master_apm {0}}  [get_bd_intf_pins pmcbridge_0/S_AXI]
+
 	assign_bd_address
 	
 } elseif { ([lsearch $temp_options "Real-time_Processor"] != -1 )} {
@@ -80,7 +83,10 @@ if {([lsearch $temp_options Preset.VALUE] == -1) || ([lsearch $temp_options "Mic
 
 	apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {/clk_wiz_1/clk_out1 (100 MHz)} Clk_slave {Auto} Clk_xbar {/clk_wiz_1/clk_out1 (100 MHz)} Master {/microblaze_riscv_0 (Periph)} Slave {/axi_uartlite_0/S_AXI} ddr_seg {Auto} intc_ip {/microblaze_riscv_0_axi_periph} master_apm {0}}  [get_bd_intf_pins axi_uartlite_0/S_AXI]
 	apply_bd_automation -rule xilinx.com:bd_rule:board -config { Manual_Source {Auto}}  [get_bd_intf_pins axi_uartlite_0/UART]
-	
+
+    create_bd_cell -type ip -vlnv xilinx.com:ip:pmcbridge:* pmcbridge_0
+    apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {/clk_wiz_1/clk_out1 (100 MHz)} Clk_slave {Auto} Clk_xbar {/clk_wiz_1/clk_out1 (100 MHz)} Master {/microblaze_riscv_0 (Periph)} Slave {/pmcbridge_0/S_AXI} ddr_seg {Auto} intc_ip {/microblaze_riscv_0_axi_periph} master_apm {0}}  [get_bd_intf_pins pmcbridge_0/S_AXI]
+
 	assign_bd_address
 	set_property range 32K [get_bd_addr_segs {microblaze_riscv_0/Data/SEG_axi_bram_ctrl_0_Mem0}]
 	set_property range 32K [get_bd_addr_segs {microblaze_riscv_0/Instruction/SEG_axi_bram_ctrl_0_Mem0}]
@@ -120,7 +126,10 @@ if {([lsearch $temp_options Preset.VALUE] == -1) || ([lsearch $temp_options "Mic
 	
 	apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {/clk_wiz_1/clk_out1 (100 MHz)} Clk_slave {Auto} Clk_xbar {/clk_wiz_1/clk_out1 (100 MHz)} Master {/microblaze_riscv_0 (Periph)} Slave {/axi_uartlite_0/S_AXI} ddr_seg {Auto} intc_ip {/microblaze_riscv_0_axi_periph} master_apm {0}}  [get_bd_intf_pins axi_uartlite_0/S_AXI]
 	apply_bd_automation -rule xilinx.com:bd_rule:board -config { Manual_Source {Auto}}  [get_bd_intf_pins axi_uartlite_0/UART]
-	
+
+    create_bd_cell -type ip -vlnv xilinx.com:ip:pmcbridge:* pmcbridge_0
+    apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {/clk_wiz_1/clk_out1 (100 MHz)} Clk_slave {Auto} Clk_xbar {/clk_wiz_1/clk_out1 (100 MHz)} Master {/microblaze_riscv_0 (Periph)} Slave {/pmcbridge_0/S_AXI} ddr_seg {Auto} intc_ip {/microblaze_riscv_0_axi_periph} master_apm {0}}  [get_bd_intf_pins pmcbridge_0/S_AXI]
+
 	assign_bd_address
 	set_property range 32K [get_bd_addr_segs {microblaze_riscv_0/Instruction/SEG_axi_bram_ctrl_0_Mem0}]
 	set_property range 32K [get_bd_addr_segs {microblaze_riscv_0/Data/SEG_axi_bram_ctrl_0_Mem0}]


### PR DESCRIPTION
CR-1251869 - Updated CED Design's
Microblaze_design_presets - Updated init.tcl to not show SCU200 Board as it is not supported. Added PMC Bridge IP for SCU35 MB Microcontroller CED, part based CEDs - mb_preset_xcsu, mb_v_preset_xcsu templates.