### PR TITLE
CR-1272184 Fix PLL lock issue for vek280 and vek385

### DIFF
--- a/ced/Xilinx/IPI/chipscopy/chipscopy_ex_bd.tcl
+++ b/ced/Xilinx/IPI/chipscopy/chipscopy_ex_bd.tcl
@@ -1233,13 +1233,22 @@ proc create_root_design_vek280 { parentCell } {
   create_quad [current_bd_instance .] gtyp_quad_106 X0Y8 GTYP 10.3125 156.25 
   
    # Create instance: gty_quad_201
-  create_quad [current_bd_instance .] gtyp_quad_204 X1Y4 GTYP 10.3125 100.0
+  create_quad [current_bd_instance .] gtyp_quad_204 X1Y6 GTYP 10.3125 100.0 1
   
    # Create instance: gty_quad_204
-  create_quad [current_bd_instance .] gtyp_quad_205 X1Y6 GTYP 16.0 100.0
+  create_quad [current_bd_instance .] gtyp_quad_205 X1Y6 GTYP 16.0 100.0 1
   
    # Create instance: gty_quad_205
   create_quad [current_bd_instance .] gtyp_quad_206 X1Y8 GTYP 25.0 100.0
+
+    # Shared IBUFDSGTE for the X1Y6 refclk.
+  create_bd_cell -type ip -vlnv xilinx.com:ip:util_ds_buf util_ds_buf_x1y6
+  set_property CONFIG.C_BUF_TYPE {IBUFDSGTE} [get_bd_cells util_ds_buf_x1y6]
+  make_bd_intf_pins_external [get_bd_intf_pins util_ds_buf_x1y6/CLK_IN_D]
+  set_property name bridge_refclkX1Y6_diff_gt_ref_clock [get_bd_intf_ports CLK_IN_D_0]
+  connect_bd_net [get_bd_pins util_ds_buf_x1y6/IBUF_OUT] \
+    [get_bd_pins gtyp_quad_204/gt_refclk_in] \
+    [get_bd_pins gtyp_quad_205/gt_refclk_in] 
   
    # Create interface connections
   connect_bd_intf_net -intf_net axi_noc_0_CH0_LPDDR4_0 [get_bd_intf_ports ch0_lpddr4_trip1] [get_bd_intf_pins axi_noc_0/CH0_LPDDR4_0]
@@ -1690,18 +1699,24 @@ proc create_root_design_vek385_reva { parentCell } {
 
   # Must create quads after CIPs as the apb3 clk is connected to pl_out_clk
 
-      # Create instance: gtyp_quad_200
-  create_quad [current_bd_instance .] gtyp_quad_106 X0Y2 GTYP 25.0 100.0
-  
-   # Create instance: gtyp_quad_201
-  create_quad [current_bd_instance .] gtyp_quad_107 X0Y4 GTYP 16.0 100.0
-  
-   # Create instance: gtm_quad_204
-  create_quad [current_bd_instance .] gtyp_quad_205 X1Y0 GTYP 20 156.25
-  
-   # Create instance: gtm_quad_205
-  create_quad [current_bd_instance .] gtyp_quad_206 X1Y2 GTYP 10 156.25
- 
+  # Same quads / GT settings as vek385_revb: three quads share refclk X1Y2.
+  # Use share_refclk=1 so create_quad does NOT instantiate its own util_ds_buf
+  # / external diff port. We instantiate ONE shared IBUFDSGTE here and fan its
+  # single-ended IBUF_OUT to each quad's gt_refclk_in.
+  create_quad [current_bd_instance .] gtyp_quad_205 X1Y2 GTYP 16.0 322.265 1
+  create_quad [current_bd_instance .] gtyp_quad_206 X1Y2 GTYP 20   322.265 1
+  create_quad [current_bd_instance .] gtyp_quad_207 X1Y2 GTYP 10   322.265 1
+
+  # Shared IBUFDSGTE for the X1Y2 refclk.
+  create_bd_cell -type ip -vlnv xilinx.com:ip:util_ds_buf util_ds_buf_x1y2
+  set_property CONFIG.C_BUF_TYPE {IBUFDSGTE} [get_bd_cells util_ds_buf_x1y2]
+  make_bd_intf_pins_external [get_bd_intf_pins util_ds_buf_x1y2/CLK_IN_D]
+  set_property name bridge_refclkX1Y2_diff_gt_ref_clock [get_bd_intf_ports CLK_IN_D_0]
+  connect_bd_net [get_bd_pins util_ds_buf_x1y2/IBUF_OUT] \
+    [get_bd_pins gtyp_quad_205/gt_refclk_in] \
+    [get_bd_pins gtyp_quad_206/gt_refclk_in] \
+    [get_bd_pins gtyp_quad_207/gt_refclk_in]
+
 
   # Create interface connections
   connect_bd_intf_net -intf_net axi_noc2_C0_CH0_LPDDR5_0 [get_bd_intf_ports ch0_lpddr5] [get_bd_intf_pins axi_noc2_0/C0_CH0_LPDDR5] 
@@ -1723,7 +1738,7 @@ proc create_root_design_vek385_reva { parentCell } {
   connect_bd_intf_net -intf_net ps_wizard_0_FPD_AXI_NOC7 [get_bd_intf_pins ps_wizard_0/FPD_AXI_NOC7] [get_bd_intf_pins axi_noc2_0/S10_AXI]
 
   # Create port connections
-  connect_bd_net -net clk_wizard_0_clk_out1 [get_bd_pins clk_wizard_0/clk_out1] [get_bd_pins axi_noc2_0/aclk2] [get_bd_pins gtyp_quad_106/apb3clk] [get_bd_pins gtyp_quad_107/apb3clk] [get_bd_pins gtyp_quad_205/apb3clk] [get_bd_pins gtyp_quad_206/apb3clk] [get_bd_pins noc_tg_bc/pclk] [get_bd_pins proc_sys_reset_0/slowest_sync_clk]
+  connect_bd_net -net clk_wizard_0_clk_out1 [get_bd_pins clk_wizard_0/clk_out1] [get_bd_pins axi_noc2_0/aclk2] [get_bd_pins gtyp_quad_205/apb3clk] [get_bd_pins gtyp_quad_206/apb3clk] [get_bd_pins gtyp_quad_207/apb3clk] [get_bd_pins noc_tg_bc/pclk] [get_bd_pins proc_sys_reset_0/slowest_sync_clk]
   connect_bd_net -net clk_wizard_0_clk_out2 [get_bd_pins clk_wizard_0/clk_out2] [get_bd_pins counters/clk100]
   connect_bd_net -net clk_wizard_0_clk_out3 [get_bd_pins clk_wizard_0/clk_out3] [get_bd_pins counters/clk200]
   connect_bd_net -net clk_wizard_0_clk_out4 [get_bd_pins axi_noc2_0/aclk3] [get_bd_pins clk_wizard_0/clk_out4] [get_bd_pins noc_tg_bc/clk]
@@ -2216,17 +2231,25 @@ proc create_root_design_vek385_revb { parentCell } {
   ] $ps_wizard_0
 
 
-      # Create instance: gtyp_quad_200
-  create_quad [current_bd_instance .] gtyp_quad_106 X0Y2 GTYP 25.0 100.0
-  
-   # Create instance: gtyp_quad_201
-  create_quad [current_bd_instance .] gtyp_quad_107 X0Y4 GTYP 16.0 100.0
-  
-   # Create instance: gtm_quad_204
-  create_quad [current_bd_instance .] gtyp_quad_205 X1Y0 GTYP 20 156.25
-  
-   # Create instance: gtm_quad_205
-  create_quad [current_bd_instance .] gtyp_quad_206 X1Y2 GTYP 10 156.25
+      # Create instance: gtyp_quad_106 (owns refclk X0Y2)
+  #create_quad [current_bd_instance .] gtyp_quad_106 X0Y2 GTYP 25.0 100.0
+
+  # All three quads below share refclk X1Y2. Use share_refclk=1 so create_quad
+  # skips its own util_ds_buf / external port. We create ONE shared IBUFDSGTE
+  # buffer here and fan its single-ended IBUF_OUT to each quad's gt_refclk_in.
+  create_quad [current_bd_instance .] gtyp_quad_205 X1Y2 GTYP 16.0 322.265 1
+  create_quad [current_bd_instance .] gtyp_quad_206 X1Y2 GTYP 20   322.265 1
+  create_quad [current_bd_instance .] gtyp_quad_207 X1Y2 GTYP 10   322.265 1
+
+  # Shared IBUFDSGTE for the X1Y2 refclk.
+  create_bd_cell -type ip -vlnv xilinx.com:ip:util_ds_buf util_ds_buf_x1y2
+  set_property CONFIG.C_BUF_TYPE {IBUFDSGTE} [get_bd_cells util_ds_buf_x1y2]
+  make_bd_intf_pins_external [get_bd_intf_pins util_ds_buf_x1y2/CLK_IN_D]
+  set_property name bridge_refclkX1Y2_diff_gt_ref_clock [get_bd_intf_ports CLK_IN_D_0]
+  connect_bd_net [get_bd_pins util_ds_buf_x1y2/IBUF_OUT] \
+    [get_bd_pins gtyp_quad_205/gt_refclk_in] \
+    [get_bd_pins gtyp_quad_206/gt_refclk_in] \
+    [get_bd_pins gtyp_quad_207/gt_refclk_in]
 
   # Create instance: util_ds_buf_0, and set properties
   set util_ds_buf_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:util_ds_buf:2.2 util_ds_buf_0 ]
@@ -2237,18 +2260,12 @@ proc create_root_design_vek385_revb { parentCell } {
 
 
   # Create interface connections
-  connect_bd_intf_net -intf_net CLK_IN_D_0_1 [get_bd_intf_ports bridge_refclkX0Y2_diff_gt_ref_clock] [get_bd_intf_pins gtyp_quad_106/bridge_refclkX0Y2_diff_gt_ref_clock]
-  connect_bd_intf_net -intf_net CLK_IN_D_0_2 [get_bd_intf_ports bridge_refclkX0Y4_diff_gt_ref_clock] [get_bd_intf_pins gtyp_quad_107/bridge_refclkX0Y4_diff_gt_ref_clock]
-  connect_bd_intf_net -intf_net CLK_IN_D_0_3 [get_bd_intf_ports bridge_refclkX1Y0_diff_gt_ref_clock] [get_bd_intf_pins gtyp_quad_205/bridge_refclkX1Y0_diff_gt_ref_clock]
-  connect_bd_intf_net -intf_net CLK_IN_D_0_4 [get_bd_intf_ports bridge_refclkX1Y2_diff_gt_ref_clock] [get_bd_intf_pins gtyp_quad_206/bridge_refclkX1Y2_diff_gt_ref_clock]
   connect_bd_intf_net -intf_net axi_noc2_0_M00_AXI [get_bd_intf_pins axi_noc2_0/M00_AXI] [get_bd_intf_pins noc_tg_bc/SLOT_0_AXI]
   set_property HDL_ATTRIBUTE.DEBUG {true} [get_bd_intf_nets axi_noc2_0_M00_AXI]
   connect_bd_intf_net -intf_net axi_noc2_0_M01_AXI [get_bd_intf_pins axi_noc2_0/M01_AXI] [get_bd_intf_pins noc_tg_bc/S00_AXI]
   connect_bd_intf_net -intf_net axi_noc2_C0_CH0_LPDDR5_0 [get_bd_intf_ports ch0_lpddr5] [get_bd_intf_pins axi_noc2_0/C0_CH0_LPDDR5]
-  connect_bd_intf_net -intf_net gtwiz_versal_Quad0_GT_Serial [get_bd_intf_ports Quad0_GT_Serial_0] [get_bd_intf_pins gtyp_quad_106/Quad0_GT_Serial_0]
-  connect_bd_intf_net -intf_net gtwiz_versal_Quad0_GT_Serial1 [get_bd_intf_ports Quad0_GT_Serial_1] [get_bd_intf_pins gtyp_quad_107/Quad0_GT_Serial_1]
-  connect_bd_intf_net -intf_net gtwiz_versal_Quad0_GT_Serial2 [get_bd_intf_ports Quad0_GT_Serial_2] [get_bd_intf_pins gtyp_quad_205/Quad0_GT_Serial_2]
-  connect_bd_intf_net -intf_net gtwiz_versal_Quad0_GT_Serial3 [get_bd_intf_ports Quad0_GT_Serial_3] [get_bd_intf_pins gtyp_quad_206/Quad0_GT_Serial_3]
+  # Quad0_GT_Serial_{0,1,2} external ports were already auto-connected by
+  # make_bd_intf_pins_external inside create_quad; no explicit connection needed here.
   connect_bd_intf_net -intf_net lpddr5_clk0_1_1 [get_bd_intf_ports lpddr5_clk0_1] [get_bd_intf_pins util_ds_buf_0/CLK_IN_D]
   connect_bd_intf_net -intf_net noc_tg_M_AXI [get_bd_intf_pins axi_noc2_0/S00_AXI] [get_bd_intf_pins noc_tg_bc/M_AXI]
   connect_bd_intf_net -intf_net ps_wizard_0_FPD_AXI_NOC0 [get_bd_intf_pins ps_wizard_0/FPD_AXI_NOC0] [get_bd_intf_pins axi_noc2_0/S03_AXI]
@@ -2264,10 +2281,9 @@ proc create_root_design_vek385_revb { parentCell } {
 
   # Create port connections
   connect_bd_net -net clk_wizard_0_clk_out1  [get_bd_pins clk_wizard_0/clk_out1] \
-  [get_bd_pins gtyp_quad_106/apb3clk] \
-  [get_bd_pins gtyp_quad_107/apb3clk] \
   [get_bd_pins gtyp_quad_205/apb3clk] \
   [get_bd_pins gtyp_quad_206/apb3clk] \
+  [get_bd_pins gtyp_quad_207/apb3clk] \
   [get_bd_pins noc_tg_bc/pclk] \
   [get_bd_pins axi_noc2_0/aclk2] \
   [get_bd_pins proc_sys_reset_0/slowest_sync_clk]
@@ -2413,4 +2429,3 @@ preplace cgraphic comment_0 place top -250 -80 textcolor 4 linecolor 3 linewidth
   save_bd_design
 }
 ####
-

--- a/ced/Xilinx/IPI/chipscopy/gt_help.tcl
+++ b/ced/Xilinx/IPI/chipscopy/gt_help.tcl
@@ -1,6 +1,12 @@
 
 
-proc create_quad {parentCell nameHier refclk_name gt_type line_rate refclk_freq} {
+proc create_quad {parentCell nameHier refclk_name gt_type line_rate refclk_freq {share_refclk 0}} {
+    # share_refclk: when non-zero, the quad does NOT instantiate its own
+    # util_ds_buf / external diff refclk port. Instead, after grouping, a
+    # single-ended hier pin named 'gt_refclk_in' is exposed and wired to
+    # gtwiz_versal/QUAD0_GTREFCLK0. The caller is responsible for creating ONE
+    # shared util_ds_buf (IBUFDSGTE) at the parent level and connecting its
+    # IBUF_OUT (single-ended) to gt_refclk_in of each sharing quad.
     set parentObj [get_bd_cells $parentCell]
     # Set parent object as current
     current_bd_instance $parentObj
@@ -15,20 +21,24 @@ proc create_quad {parentCell nameHier refclk_name gt_type line_rate refclk_freq}
         } else {
             set pam_sel "NRZ"
         }
-	create_bd_cell -type ip -vlnv xilinx.com:ip:util_ds_buf util_ds_buf
-	set_property CONFIG.C_BUF_TYPE {IBUFDS_GTME5} [get_bd_cells util_ds_buf]
-	make_bd_intf_pins_external  [get_bd_intf_pins util_ds_buf/CLK_IN_D1]
-	#set_property name gt_refclk_$name [get_bd_intf_ports CLK_IN_D1_0]
-	create_bd_cell -type inline_hdl -vlnv xilinx.com:inline_hdl:ilconstant xlconstant
-	set_property CONFIG.CONST_VAL {0} [get_bd_cells xlconstant]
-	connect_bd_net [get_bd_pins xlconstant/dout] [get_bd_pins util_ds_buf/IBUFDS_GTME5_CEB]
+	if {!$share_refclk} {
+	  create_bd_cell -type ip -vlnv xilinx.com:ip:util_ds_buf util_ds_buf
+	  set_property CONFIG.C_BUF_TYPE {IBUFDS_GTME5} [get_bd_cells util_ds_buf]
+	  make_bd_intf_pins_external  [get_bd_intf_pins util_ds_buf/CLK_IN_D1]
+	  #set_property name gt_refclk_$name [get_bd_intf_ports CLK_IN_D1_0]
+	  create_bd_cell -type inline_hdl -vlnv xilinx.com:inline_hdl:ilconstant xlconstant
+	  set_property CONFIG.CONST_VAL {0} [get_bd_cells xlconstant]
+	  connect_bd_net [get_bd_pins xlconstant/dout] [get_bd_pins util_ds_buf/IBUFDS_GTME5_CEB]
+	}
         set width [expr $line_rate > 57.0 ? 320 : 160]
         set user_settings_dict [dict create TX_LINE_RATE $line_rate TX_REFCLK_FREQUENCY $refclk_freq RX_LINE_RATE $line_rate RX_REFCLK_FREQUENCY $refclk_freq GT_TYPE GTM RX_PAM_SEL $pam_sel TX_PAM_SEL $pam_sel TX_USER_DATA_WIDTH $width RX_USER_DATA_WIDTH $width TX_OUTCLK_SOURCE TXPROGDIVCLK RX_OUTCLK_SOURCE RXPROGDIVCLK]
     } else {
-	create_bd_cell -type ip -vlnv xilinx.com:ip:util_ds_buf util_ds_buf
-	set_property CONFIG.C_BUF_TYPE {IBUFDSGTE} [get_bd_cells util_ds_buf]
-	make_bd_intf_pins_external  [get_bd_intf_pins util_ds_buf/CLK_IN_D]
-	#set_property name gt_refclk_$name [get_bd_intf_ports CLK_IN_D_0]
+	if {!$share_refclk} {
+	  create_bd_cell -type ip -vlnv xilinx.com:ip:util_ds_buf util_ds_buf
+	  set_property CONFIG.C_BUF_TYPE {IBUFDSGTE} [get_bd_cells util_ds_buf]
+	  make_bd_intf_pins_external  [get_bd_intf_pins util_ds_buf/CLK_IN_D]
+	  #set_property name gt_refclk_$name [get_bd_intf_ports CLK_IN_D_0]
+	}
         set user_settings_dict [dict create TX_LINE_RATE $line_rate TX_REFCLK_FREQUENCY $refclk_freq RX_LINE_RATE $line_rate RX_REFCLK_FREQUENCY $refclk_freq ]
     }
 
@@ -68,23 +78,38 @@ proc create_quad {parentCell nameHier refclk_name gt_type line_rate refclk_freq}
 
 	make_bd_intf_pins_external  [get_bd_intf_pins gtwiz_versal/Quad0_GT_Serial]
 
-        if {$gt_type eq "GTM"} {
-          connect_bd_net [get_bd_pins util_ds_buf/IBUFDS_GTME5_O] [get_bd_pins gtwiz_versal/QUAD0_GTREFCLK0]
-	} else {
-          connect_bd_net [get_bd_pins util_ds_buf/IBUF_OUT] [get_bd_pins gtwiz_versal/QUAD0_GTREFCLK0]
-	}
+        if {!$share_refclk} {
+          if {$gt_type eq "GTM"} {
+            connect_bd_net [get_bd_pins util_ds_buf/IBUFDS_GTME5_O] [get_bd_pins gtwiz_versal/QUAD0_GTREFCLK0]
+	  } else {
+            connect_bd_net [get_bd_pins util_ds_buf/IBUF_OUT] [get_bd_pins gtwiz_versal/QUAD0_GTREFCLK0]
+	  }
+        }
 
     #puts "renaming refclks"
-    if {$gt_type eq "GTM"} {
-      set_property name bridge_refclk${refclk_name}_diff_gt_ref_clock [get_bd_intf_ports CLK_IN_D1_0]  	
-    } else {
-      set_property name bridge_refclk${refclk_name}_diff_gt_ref_clock [get_bd_intf_ports CLK_IN_D_0]
+    if {!$share_refclk} {
+      if {$gt_type eq "GTM"} {
+        set_property name bridge_refclk${refclk_name}_diff_gt_ref_clock [get_bd_intf_ports CLK_IN_D1_0]
+      } else {
+        set_property name bridge_refclk${refclk_name}_diff_gt_ref_clock [get_bd_intf_ports CLK_IN_D_0]
+      }
     }
     puts "creating hierarchy and clock port"
-    if {$gt_type eq "GTM"} { 
+    if {$share_refclk} {
+      # No util_ds_buf inside the hier; caller drives gt_refclk_in.
+      group_bd_cells $nameHier [get_bd_cells bufg_gt_tx] [get_bd_cells bridge] [get_bd_cells gtwiz_versal] [get_bd_cells bufg_gt_rx]
+    } elseif {$gt_type eq "GTM"} { 
       group_bd_cells $nameHier [get_bd_cells bufg_gt_tx] [get_bd_cells bridge] [get_bd_cells gtwiz_versal] [get_bd_cells bufg_gt_rx] [get_bd_cells util_ds_buf] [get_bd_cells xlconstant]
     } else {
       group_bd_cells $nameHier [get_bd_cells bufg_gt_tx] [get_bd_cells bridge] [get_bd_cells gtwiz_versal] [get_bd_cells bufg_gt_rx] [get_bd_cells util_ds_buf]
+    }
+    if {$share_refclk} {
+      # Expose gtwiz_versal/QUAD0_GTREFCLK0 as a single-ended hier input pin so
+      # the caller can drive it from a shared IBUFDSGTE's IBUF_OUT.
+      current_bd_instance $nameHier
+      create_bd_pin -dir I -type clk gt_refclk_in
+      connect_bd_net [get_bd_pins gt_refclk_in] [get_bd_pins gtwiz_versal/QUAD0_GTREFCLK0]
+      current_bd_instance $parentObj
     }
     current_bd_instance $nameHier
     create_bd_pin -dir I -type clk apb3clk

--- a/ced/Xilinx/IPI/chipscopy/init.tcl
+++ b/ced/Xilinx/IPI/chipscopy/init.tcl
@@ -59,9 +59,12 @@ proc getSupportedBoards {} {
       # Include both Rev A and Rev B boards if available. In Vivado, the Rev B
       # board is published as a separate board (e.g. vek385_1) with "Rev B" in
       # its DISPLAY_NAME, while the original Rev A board uses "vek385".
+      # Use -latest_file_version so we pick the newest file version of each board.
       set rev_a ""
       set rev_b ""
-      foreach brd [get_boards -quiet *vek385*] {
+      foreach bp [get_board_parts -quiet -latest_file_version *vek385*] {
+        set brd [lindex [get_boards -quiet -of $bp] 0]
+        if {$brd eq ""} { continue }
         set dname [get_property -quiet DISPLAY_NAME $brd]
         # Match "Rev A" / "Rev B" as whole tokens so revisions like "Rev A1"
         # don't get picked up as Rev A.
@@ -72,14 +75,16 @@ proc getSupportedBoards {} {
         }
       }
       if {$rev_a eq "" && $rev_b eq ""} {
-        set p [lindex [get_board_parts *${b}:*] 0]
+        set p [lindex [get_board_parts -quiet -latest_file_version *${b}:*] 0]
         lappend r [get_boards -of $p]
       } else {
         if {$rev_a ne ""} { lappend r $rev_a }
         if {$rev_b ne ""} { lappend r $rev_b }
       }
     } else {
-      set p [lindex [get_board_parts *${b}:*] 0]
+      # Use -latest_file_version so the GUI shows the newest available
+      # board file version (e.g. vck190 3.4 instead of 2.2).
+      set p [lindex [get_board_parts -quiet -latest_file_version *${b}:*] 0]
       lappend r [get_boards -of $p]
     }
   }
@@ -182,5 +187,4 @@ proc createDesign {design_name options} {
   open_bd_design [get_bd_designs -filter {NAME == "chipscopy"}]
   # exec echo "PHASE_DONE" > ${proj_dir}/[current_project].srcs/[current_fileset]/bd/chipscopy/ip/chipscopy_noc_tg_0/chipscopy_noc_tg_0_synth_pattern.csv
 }
-
 

--- a/ced/Xilinx/IPI/chipscopy/xdc/versal_ibert_vek280.xdc
+++ b/ced/Xilinx/IPI/chipscopy/xdc/versal_ibert_vek280.xdc
@@ -7,13 +7,10 @@ create_clock -period 6.4 [get_ports bridge_refclkX0Y8_diff_gt_ref_clock_clk_p[0]
 # refclkX1Y4 : 10.3125 Gbps with 100.00 MHz
 set_property LOC GTYP_QUAD_X1Y2 [get_cells chipscopy_i/gtyp_quad_204/gtwiz_versal/inst/intf_quad_map_inst/quad_top_inst/gt_quad_base_0_inst/inst/quad_inst]
 
-set_property LOC GTYP_REFCLK_X1Y4 [get_cells chipscopy_i/gtyp_quad_204/util_ds_buf/U0/USE_IBUFDS_GTE5.GEN_IBUFDS_GTE5[0].IBUFDS_GTE5_I]
-create_clock -period 10.0 [get_ports bridge_refclkX1Y4_diff_gt_ref_clock_clk_p[0]]
-
 # refclkX1Y6 : 16 Gbps with 100.00 MHz
 set_property LOC GTYP_QUAD_X1Y3 [get_cells chipscopy_i/gtyp_quad_205/gtwiz_versal/inst/intf_quad_map_inst/quad_top_inst/gt_quad_base_0_inst/inst/quad_inst]
 
-set_property LOC GTYP_REFCLK_X1Y6 [get_cells chipscopy_i/gtyp_quad_205/util_ds_buf/U0/USE_IBUFDS_GTE5.GEN_IBUFDS_GTE5[0].IBUFDS_GTE5_I]
+set_property LOC GTYP_REFCLK_X1Y6 [get_cells chipscopy_i/util_ds_buf_x1y6/U0/USE_IBUFDS_GTE5.GEN_IBUFDS_GTE5[0].IBUFDS_GTE5_I]
 create_clock -period 10.0 [get_ports bridge_refclkX1Y6_diff_gt_ref_clock_clk_p[0]]
 
 # refclkX1Y8 : 25 Gbps with 100.00 MHz

--- a/ced/Xilinx/IPI/chipscopy/xdc/versal_ibert_vek385.xdc
+++ b/ced/Xilinx/IPI/chipscopy/xdc/versal_ibert_vek385.xdc
@@ -1,26 +1,17 @@
-# refclkX0Y2 : 25 Gbps with 100 MHz
-set_property LOC GTYP_QUAD_X0Y1 [get_cells chipscopy_i/gtyp_quad_106/gtwiz_versal/inst/intf_quad_map_inst/quad_top_inst/gt_quad_base_0_inst/inst/quad_inst]
+# vek385 (reva and revb): three GTYP quads all sharing refclk X1Y2 (322.265 MHz).
+# A single IBUFDSGTE (util_ds_buf_x1y2) drives the shared refclk to all three quads.
+#
+# gtyp_quad_205 : 16.0 Gbps  -> GTYP_QUAD_X1Y1
+# gtyp_quad_206 : 20.0 Gbps  -> GTYP_QUAD_X1Y2
+# gtyp_quad_207 : 10.0 Gbps  -> GTYP_QUAD_X1Y3
+# Shared refclk: GTYP_REFCLK_X1Y2 (period = 1000 / 322.265 ~= 3.103 ns)
 
-set_property LOC GTYP_REFCLK_X0Y2 [get_cells  chipscopy_i/gtyp_quad_106/util_ds_buf/U0/USE_IBUFDS_GTE5.GEN_IBUFDS_GTE5[0].IBUFDS_GTE5_I]
-create_clock -period 10.0 [get_ports bridge_refclkX0Y2_diff_gt_ref_clock_clk_p[0]]
-
-# refclkX0Y4 : 16 Gbps with 100.00 MHz
-set_property LOC GTYP_QUAD_X0Y2 [get_cells chipscopy_i/gtyp_quad_107/gtwiz_versal/inst/intf_quad_map_inst/quad_top_inst/gt_quad_base_0_inst/inst/quad_inst]
-
-set_property LOC GTYP_REFCLK_X0Y4 [get_cells chipscopy_i/gtyp_quad_107/util_ds_buf/U0/USE_IBUFDS_GTE5.GEN_IBUFDS_GTE5[0].IBUFDS_GTE5_I]
-create_clock -period 10.0 [get_ports bridge_refclkX0Y4_diff_gt_ref_clock_clk_p[0]]
-
-# refclkX1Y0 : 20 Gbps with 156.25 MHz
 set_property LOC GTYP_QUAD_X1Y0 [get_cells chipscopy_i/gtyp_quad_205/gtwiz_versal/inst/intf_quad_map_inst/quad_top_inst/gt_quad_base_0_inst/inst/quad_inst]
-
-set_property LOC GTYP_REFCLK_X1Y0 [get_cells chipscopy_i/gtyp_quad_205/util_ds_buf/U0/USE_IBUFDS_GTE5.GEN_IBUFDS_GTE5[0].IBUFDS_GTE5_I]
-create_clock -period 6.4 [get_ports bridge_refclkX1Y0_diff_gt_ref_clock_clk_p[0]]
-
-# refclkX1Y2 : 10 Gbps with 156.25 MHz
 set_property LOC GTYP_QUAD_X1Y1 [get_cells chipscopy_i/gtyp_quad_206/gtwiz_versal/inst/intf_quad_map_inst/quad_top_inst/gt_quad_base_0_inst/inst/quad_inst]
+set_property LOC GTYP_QUAD_X1Y2 [get_cells chipscopy_i/gtyp_quad_207/gtwiz_versal/inst/intf_quad_map_inst/quad_top_inst/gt_quad_base_0_inst/inst/quad_inst]
 
-set_property LOC GTYP_REFCLK_X1Y2 [get_cells chipscopy_i/gtyp_quad_206/util_ds_buf/U0/USE_IBUFDS_GTE5.GEN_IBUFDS_GTE5[0].IBUFDS_GTE5_I]
-create_clock -period 6.4 [get_ports bridge_refclkX1Y2_diff_gt_ref_clock_clk_p[0]]
+set_property LOC GTYP_REFCLK_X1Y2 [get_cells chipscopy_i/util_ds_buf_x1y2/U0/USE_IBUFDS_GTE5.GEN_IBUFDS_GTE5[0].IBUFDS_GTE5_I]
+create_clock -period 3.103 [get_ports bridge_refclkX1Y2_diff_gt_ref_clock_clk_p[0]]
 
 
 set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]


### PR DESCRIPTION
Wrong refclk frequency is used, so using the same refclk which is available and sharing between quads