### PR TITLE
CR-1277929 : Smartconnect IP instance switch to legacy low area mode

### DIFF
--- a/ced/Xilinx/IPI/Versal_CPM_QDMA_EP_Design/cpm5_qdma_dual_ctrl/design_1_bd.tcl
+++ b/ced/Xilinx/IPI/Versal_CPM_QDMA_EP_Design/cpm5_qdma_dual_ctrl/design_1_bd.tcl
@@ -523,18 +523,19 @@ NONE HBM_PC1_USER_DEFINED_ADDRESS_MAP NONE} \
   set_property -dict [list \
     CONFIG.NUM_MI {2} \
     CONFIG.NUM_SI {1} \
+    CONFIG.ADVANCED_PROPERTIES {__experimental_features__ {legacy_low_area_mode 1}} \
   ] $smartconnect_0
 
 
   # Create instance: smartconnect_1, and set properties
   set smartconnect_1 [ create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect smartconnect_1 ]
   set_property CONFIG.NUM_SI {1} $smartconnect_1
-
+  set_property CONFIG.ADVANCED_PROPERTIES {__experimental_features__ {legacy_low_area_mode 1}} $smartconnect_1
 
   # Create instance: smartconnect_2, and set properties
   set smartconnect_2 [ create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect smartconnect_2 ]
   set_property CONFIG.NUM_SI {1} $smartconnect_2
-
+  set_property CONFIG.ADVANCED_PROPERTIES {__experimental_features__ {legacy_low_area_mode 1}} $smartconnect_2
 
   # Create instance: versal_cips_0, and set properties
   set versal_cips_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:versal_cips versal_cips_0 ]

--- a/ced/Xilinx/IPI/Versal_CPM_QDMA_EP_Design/create_cpm5.tcl
+++ b/ced/Xilinx/IPI/Versal_CPM_QDMA_EP_Design/create_cpm5.tcl
@@ -409,13 +409,14 @@ proc create_root_design { parentCell } {
   set_property -dict [list \
     CONFIG.NUM_MI {1} \
     CONFIG.NUM_SI {1} \
+    CONFIG.ADVANCED_PROPERTIES {__experimental_features__ {legacy_low_area_mode 1}} \
   ] $smartconnect_0
 
 
   # Create instance: smartconnect_1, and set properties
   set smartconnect_1 [ create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect smartconnect_1 ]
   set_property CONFIG.NUM_SI {1} $smartconnect_1
-
+  set_property CONFIG.ADVANCED_PROPERTIES {__experimental_features__ {legacy_low_area_mode 1}} $smartconnect_1
 
   # Create instance: versal_cips_0, and set properties
   set versal_cips_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:versal_cips versal_cips_0 ]


### PR DESCRIPTION
Smartconnect IP instance switch to legacy low area mode. Design data-path was not compartible with new version of smartconnect IP (low area architecture)