### PR TITLE
CR-1276613 : Align BMD example design with VPK360 hardware

### DIFF
--- a/ced/Xilinx/IPI/Versal_CPM6_BMD_Design/ctrl0/design_1_bd.tcl
+++ b/ced/Xilinx/IPI/Versal_CPM6_BMD_Design/ctrl0/design_1_bd.tcl
@@ -203,6 +203,7 @@ proc create_root_design { parentCell link_width lane_rate } {
   # Create instance: ps_wizard_0, and set properties
   set ps_wizard_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:ps_wizard:1.0 ps_wizard_0 ]
   set_property -dict [list \
+    CONFIG.CPM6_CONFIG(CPM6_BOARD) {VPK_360} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL0_ASPM_L0P_SUPPORT) {0} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL0_ASPM_L1_SUPPORT) {0} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL0_ATS_PRI_CAP_EN) {0} \
@@ -217,6 +218,7 @@ proc create_root_design { parentCell link_width lane_rate } {
     CONFIG.CPM6_CONFIG(CPM6_CTRL0_LINK_WIDTH) $link_width \
     CONFIG.CPM6_CONFIG(CPM6_CTRL0_MCAP_EN) {1} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL0_PASID_CAP_EN) {1} \
+    CONFIG.CPM6_CONFIG(CPM6_CTRL0_PERST) {PS_MIO_18} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL0_PF0_BAR0_SIZE) {64} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL0_PF0_BAR1_EN) {1} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL0_PF0_BAR1_SIZE) {64} \

--- a/ced/Xilinx/IPI/Versal_CPM6_BMD_Design/ctrl1/design_1_bd.tcl
+++ b/ced/Xilinx/IPI/Versal_CPM6_BMD_Design/ctrl1/design_1_bd.tcl
@@ -196,6 +196,7 @@ proc create_root_design { parentCell link_width lane_rate } {
   # Create instance: ps_wizard_0, and set properties
   set ps_wizard_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:ps_wizard:1.0 ps_wizard_0 ]
   set_property -dict [list \
+    CONFIG.CPM6_CONFIG(CPM6_BOARD) {VPK_360} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL1_ASPM_L0P_SUPPORT) {0} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL1_ASPM_L1_SUPPORT) {0} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL1_ATS_PRI_CAP_EN) {0} \
@@ -210,6 +211,7 @@ proc create_root_design { parentCell link_width lane_rate } {
     CONFIG.CPM6_CONFIG(CPM6_CTRL1_LINK_WIDTH) $link_width \
     CONFIG.CPM6_CONFIG(CPM6_CTRL1_MCAP_EN) {1} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL1_PASID_CAP_EN) {1} \
+    CONFIG.CPM6_CONFIG(CPM6_CTRL1_PERST) {PS_MIO_19} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL1_PF0_BAR0_SIZE) {64} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL1_PF0_BAR1_EN) {1} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL1_PF0_BAR1_SIZE) {64} \

--- a/ced/Xilinx/IPI/Versal_CPM6_BMD_Design/dual/design_1_bd.tcl
+++ b/ced/Xilinx/IPI/Versal_CPM6_BMD_Design/dual/design_1_bd.tcl
@@ -208,6 +208,7 @@ proc create_root_design { parentCell link_width lane_rate } {
   # Create instance: ps_wizard_0, and set properties
   set ps_wizard_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:ps_wizard:1.0 ps_wizard_0 ]
   set_property -dict [list \
+    CONFIG.CPM6_CONFIG(CPM6_BOARD) {VPK_360} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL0_ASPM_L0P_SUPPORT) {0} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL0_ASPM_L1_SUPPORT) {0} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL0_ATS_PRI_CAP_EN) {0} \
@@ -222,6 +223,7 @@ proc create_root_design { parentCell link_width lane_rate } {
     CONFIG.CPM6_CONFIG(CPM6_CTRL0_LINK_WIDTH) $link_width \
     CONFIG.CPM6_CONFIG(CPM6_CTRL0_MCAP_EN) {1} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL0_PASID_CAP_EN) {1} \
+    CONFIG.CPM6_CONFIG(CPM6_CTRL0_PERST) {PS_MIO_18} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL0_PF0_BAR0_SIZE) {64} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL0_PF0_BAR1_EN) {1} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL0_PF0_BAR1_SIZE) {64} \
@@ -257,6 +259,7 @@ proc create_root_design { parentCell link_width lane_rate } {
     CONFIG.CPM6_CONFIG(CPM6_CTRL1_LINK_WIDTH) $link_width \
     CONFIG.CPM6_CONFIG(CPM6_CTRL1_MCAP_EN) {1} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL1_PASID_CAP_EN) {1} \
+    CONFIG.CPM6_CONFIG(CPM6_CTRL1_PERST) {PS_MIO_19} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL1_PF0_BAR0_64BIT) {0} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL1_PF0_BAR0_SIZE) {64} \
     CONFIG.CPM6_CONFIG(CPM6_CTRL1_PF0_BAR1_EN) {1} \


### PR DESCRIPTION
it sets CPM6_BOARD=VPK_360 and CPM6_CTRL0/1_PERST=PS_MIO_18/19 on ctrl0/ctrl1/dual, per your senior's hardware-alignment request.